### PR TITLE
Switch environment variable for Broker for `tansu cat` commands

### DIFF
--- a/tansu-cli/src/cli/cat.rs
+++ b/tansu-cli/src/cli/cat.rs
@@ -24,7 +24,7 @@ use url::Url;
 pub(super) enum Command {
     #[command(about = "Produce Avro/JSON/Protobuf messages to a topic")]
     Produce {
-        #[arg(long, default_value = DEFAULT_BROKER, env = "ADVERTISED_LISTENER_URL", help = "The URL of the broker to produce messages into")]
+        #[arg(long, default_value = DEFAULT_BROKER, env = "BROKER_URL", help = "The URL of the broker to produce messages into")]
         broker: Url,
 
         #[clap(value_parser, help = "The topic to produce messages into")]
@@ -54,7 +54,7 @@ pub(super) enum Command {
 
     #[command(about = "Consume Avro/JSON/Protobuf messages from a topic")]
     Consume {
-        #[arg(long, default_value = DEFAULT_BROKER, env = "ADVERTISED_LISTENER_URL", help = "The URL of the broker to consume messages from")]
+        #[arg(long, default_value = DEFAULT_BROKER, env = "BROKER_URL", help = "The URL of the broker to consume messages from")]
         broker: Url,
 
         #[clap(value_parser, help = "The topic to consume messages from")]


### PR DESCRIPTION
This switches the environment variable that can be used to configure the broker URL for the `tansu cat consume` and `tansu cat produce` commands from `ADVERTISED_LISTENER_URL` (which doesn't really make sense here) to `BROKER_URL`.

---

While working on this, I also noticed the `tansu cat consume --partition-max-bytes` flag, which has a help text of "The partition to consume from" and a default value of `1048576`. This doesn't really make sense to me. I looked through the source code and couldn't really work out what the flag is expected to do (I'm a Rust rookie). However, I thought I would mention it here if that's something that should be corrected at the same time.