### PR TITLE
Add schema registry cache expiration support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6260,6 +6260,7 @@ version = "0.4.9"
 dependencies = [
  "clap",
  "dotenv",
+ "humantime",
  "regex",
  "tansu-broker",
  "tansu-cat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ getrandom = "0.3"
 glob = "0.3.2"
 governor = "0.10.0"
 http-body-util = "0.1"
+humantime = "2.2.0"
 hyper = { version = "1.3", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
 iceberg = "0.5"

--- a/tansu-broker/tests/person.rs
+++ b/tansu-broker/tests/person.rs
@@ -163,7 +163,11 @@ mod pg {
 
         let schemas = Url::parse("file://../etc/schema")
             .map_err(Error::from)
-            .and_then(|url| Registry::try_from(url).map_err(Into::into))
+            .and_then(|url| {
+                Registry::builder_try_from_url(&url)
+                    .map(|builder| builder.build())
+                    .map_err(Into::into)
+            })
             .map(Some)?;
 
         Url::parse("tcp://127.0.0.1/")
@@ -226,7 +230,11 @@ mod in_memory {
 
         let schemas = Url::parse("file://../etc/schema")
             .map_err(Error::from)
-            .and_then(|url| Registry::try_from(url).map_err(Into::into))
+            .and_then(|url| {
+                Registry::builder_try_from_url(&url)
+                    .map(|builder| builder.build())
+                    .map_err(Into::into)
+            })
             .map(Some)?;
 
         Url::parse("tcp://127.0.0.1/")

--- a/tansu-cat/src/consume.rs
+++ b/tansu-cat/src/consume.rs
@@ -183,7 +183,7 @@ impl TryFrom<Configuration> for Consume {
         configuration
             .schema_registry
             .as_ref()
-            .map(Registry::try_from)
+            .map(|url| Registry::builder_try_from_url(url).map(|builder| builder.build()))
             .transpose()
             .map(|registry| Self {
                 configuration,

--- a/tansu-cat/src/produce.rs
+++ b/tansu-cat/src/produce.rs
@@ -136,7 +136,7 @@ impl TryFrom<Configuration> for Produce {
         configuration
             .schema_registry
             .as_ref()
-            .map(Registry::try_from)
+            .map(|url| Registry::builder_try_from_url(url).map(|builder| builder.build()))
             .transpose()
             .map(|registry| Self {
                 configuration,

--- a/tansu-cli/Cargo.toml
+++ b/tansu-cli/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 clap.workspace = true
 dotenv.workspace = true
+humantime.workspace = true
 regex.workspace = true
 tansu-broker.workspace = true
 tansu-cat.workspace = true

--- a/tansu-cli/src/cli/broker.rs
+++ b/tansu-cli/src/cli/broker.rs
@@ -12,13 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
 use crate::{EnvVarExp, Error, Result};
 
 use super::DEFAULT_BROKER;
 use clap::{Parser, Subcommand};
 use tansu_broker::{NODE_ID, broker::Broker, coordinator::group::administrator::Controller};
 use tansu_sans_io::ErrorCode;
-use tansu_schema::lake::{self};
+use tansu_schema::{
+    Registry,
+    lake::{self},
+};
 use tansu_storage::StorageContainer;
 use tracing::debug;
 use url::Url;
@@ -63,6 +68,10 @@ pub(super) struct Arg {
     /// Schema registry examples are: file://./etc/schema or s3://tansu/, containing: topic.json, topic.proto or topic.avsc
     #[arg(long, env = "SCHEMA_REGISTRY")]
     schema_registry: Option<EnvVarExp<Url>>,
+
+    /// Schema registry cache expiry duration
+    #[arg(long,value_parser = humantime::parse_duration)]
+    schema_registry_cache_expiry: Option<Duration>,
 
     /// OTEL Exporter OTLP endpoint
     #[arg(long, env = "OTEL_EXPORTER_OTLP_ENDPOINT")]
@@ -137,9 +146,17 @@ impl TryFrom<Arg> for Broker<Controller<StorageContainer>, StorageContainer> {
         let storage_engine = args.storage_engine.into_inner();
         let advertised_listener = args.advertised_listener_url.into_inner();
         let listener = args.listener_url.into_inner();
-        let schema = args
+        let schema_registry = args
             .schema_registry
-            .map(|env_var_exp| env_var_exp.into_inner());
+            .map(|env_var_exp| env_var_exp.into_inner())
+            .map(|object_store| {
+                Registry::builder_try_from_url(&object_store).map(|registry| {
+                    registry
+                        .with_cache_expiry_after(args.schema_registry_cache_expiry)
+                        .build()
+                })
+            })
+            .transpose()?;
 
         let lake_house = args
             .command
@@ -176,7 +193,7 @@ impl TryFrom<Arg> for Broker<Controller<StorageContainer>, StorageContainer> {
             .incarnation_id(incarnation_id)
             .advertised_listener(advertised_listener)
             .otlp_endpoint_url(otlp_endpoint_url)
-            .schema_registry(schema)
+            .schema_registry(schema_registry)
             .lake_house(lake_house)
             .storage(storage_engine)
             .listener(listener)

--- a/tansu-generator/src/lib.rs
+++ b/tansu-generator/src/lib.rs
@@ -144,7 +144,8 @@ impl TryFrom<Configuration> for Generate {
     type Error = Error;
 
     fn try_from(configuration: Configuration) -> Result<Self, Self::Error> {
-        Registry::try_from(&configuration.schema_registry)
+        Registry::builder_try_from_url(&configuration.schema_registry)
+            .map(|builder| builder.build())
             .map(|registry| Self {
                 configuration,
                 registry,

--- a/tansu-schema/src/proto.rs
+++ b/tansu-schema/src/proto.rs
@@ -138,7 +138,7 @@ impl Schema {
         data_type: DataType,
         nullable: bool,
     ) -> Field {
-        debug!(?path, name, ?data_type, ?nullable, ids = ?ids);
+        debug!(?path, name, ?data_type, ?nullable, ?ids);
 
         let path = append(path, name).join(".");
 
@@ -328,7 +328,7 @@ impl Schema {
         path: &[&str],
         descriptor: &MessageDescriptor,
     ) -> Vec<Field> {
-        debug!(?path, descriptor_full_name = ?descriptor.full_name());
+        debug!(?path, ?ids, descriptor_full_name = ?descriptor.full_name());
 
         descriptor
             .fields()
@@ -482,7 +482,7 @@ impl Schema {
         path: &[&str],
         runtime_type: &RuntimeType,
     ) -> Box<dyn ArrayBuilder> {
-        debug!(?path, ?runtime_type);
+        debug!(?path, ?runtime_type, ?ids);
 
         match runtime_type {
             RuntimeType::U32 | RuntimeType::I32 | RuntimeType::Enum(_) => {
@@ -653,7 +653,7 @@ impl Schema {
         path: &[&str],
         descriptor: &MessageDescriptor,
     ) -> Vec<Box<dyn ArrayBuilder>> {
-        debug!(?path, ?descriptor);
+        debug!(?path, descriptor = descriptor.full_name(), ?ids);
 
         descriptor
             .fields()
@@ -2025,6 +2025,7 @@ impl AsArrow for Schema {
             columns.iter_mut().map(|builder| builder.finish()).collect(),
         )
         .inspect_err(|err| debug!(?err))
+        .inspect(|record_batch| debug!(?record_batch))
         .map_err(Into::into)
     }
 }

--- a/tansu-schema/tests/berg.rs
+++ b/tansu-schema/tests/berg.rs
@@ -38,6 +38,7 @@ use url::Url;
 pub mod common;
 
 pub async fn lake_store(
+    namespace: &str,
     topic: &str,
     partition: i32,
     config: DescribeConfigsResult,
@@ -46,14 +47,19 @@ pub async fn lake_store(
     let catalog_uri = &var("ICEBERG_CATALOG").unwrap_or("http://localhost:8181".into())[..];
     let location_uri = &var("DATA_LAKE").unwrap_or("s3://lake".into())[..];
     let warehouse = var("ICEBERG_WAREHOUSE").ok();
-    let namespace = alphanumeric_string(5);
 
-    debug!(catalog_uri, location_uri, ?warehouse, namespace);
+    debug!(
+        catalog_uri,
+        location_uri,
+        ?warehouse,
+        namespace,
+        ?record_batch
+    );
 
     let lake_house = House::iceberg()
         .location(Url::parse(location_uri)?)
         .catalog(Url::parse(catalog_uri)?)
-        .namespace(Some(namespace.clone()))
+        .namespace(Some(namespace.to_owned()))
         .warehouse(warehouse.clone())
         .build()?;
 
@@ -185,8 +191,16 @@ mod json {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results)?.to_string();
 
@@ -251,8 +265,16 @@ mod json {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results)?.to_string();
 
@@ -320,8 +342,16 @@ mod json {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results)?.to_string();
 
@@ -384,8 +414,16 @@ mod json {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results)?.to_string();
 
@@ -450,8 +488,16 @@ mod json {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results)?.to_string();
 
@@ -533,8 +579,16 @@ mod json {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results)?.to_string();
 
@@ -611,8 +665,16 @@ mod json {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results)?.to_string();
 
@@ -634,6 +696,7 @@ mod json {
 mod proto {
     use super::*;
     use tansu_schema::{
+        Generator as _,
         lake::LakeHouseType,
         proto::{MessageKind, Schema},
     };
@@ -711,8 +774,16 @@ mod proto {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))
         }?;
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results)?.to_string();
 
@@ -759,8 +830,16 @@ mod proto {
             .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))
             .inspect(|record_batch| debug!(?record_batch))?;
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results)?.to_string();
 
@@ -807,8 +886,16 @@ mod proto {
             .map_err(Into::into)
             .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?;
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, normalized_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            normalized_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results)?.to_string();
 
@@ -865,8 +952,16 @@ mod proto {
             .map_err(Into::into)
             .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?;
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results)?.to_string();
 
@@ -918,8 +1013,16 @@ mod proto {
             .map_err(Into::into)
             .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?;
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results)?.to_string();
 
@@ -976,8 +1079,16 @@ mod proto {
             .map_err(Into::into)
             .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?;
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results)?.to_string();
 
@@ -987,6 +1098,115 @@ mod proto {
             "+------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------+",
             "| {partition: 32123, timestamp: 1973-10-17T18:36:57, year: 1973, month: 10, day: 17} | {results: [{url: https://example.com/abc, title: a, snippets: [p, q, r]}, {url: https://example.com/def, title: b, snippets: [x, y, z]}]} |",
             "+------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------+",
+        ];
+
+        assert_eq!(pretty_results.trim().lines().collect::<Vec<_>>(), expected);
+
+        Ok(())
+    }
+
+    #[ignore]
+    #[tokio::test]
+    async fn customer_schema_migration() -> Result<()> {
+        _ = dotenv().ok();
+        let _guard = init_tracing()?;
+
+        let partition = 32123;
+
+        let record_batch_001 = {
+            let schema = Schema::try_from(Bytes::from_static(include_bytes!("migrate-001.proto")))?;
+
+            Batch::builder()
+                .record(schema.generate()?)
+                .base_timestamp(119_731_017_000)
+                .build()
+                .map_err(Into::into)
+                .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
+        };
+
+        let namespace = &alphanumeric_string(5);
+        let topic = &alphanumeric_string(5);
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch_001,
+        )
+        .await?;
+        let pretty_results = pretty_format_batches(&results)?.to_string();
+
+        let expected = vec![
+            "+------------------------------------------------------------------------------------+------------------------+",
+            "| meta                                                                               | value                  |",
+            "+------------------------------------------------------------------------------------+------------------------+",
+            "| {partition: 32123, timestamp: 1973-10-17T18:36:57, year: 1973, month: 10, day: 17} | {email_address: lorem} |",
+            "+------------------------------------------------------------------------------------+------------------------+",
+        ];
+
+        assert_eq!(pretty_results.trim().lines().collect::<Vec<_>>(), expected);
+
+        let record_batch_002 = {
+            let schema = Schema::try_from(Bytes::from_static(include_bytes!("migrate-002.proto")))?;
+
+            Batch::builder()
+                .record(schema.generate()?)
+                .base_timestamp(119_731_017_000)
+                .build()
+                .map_err(Into::into)
+                .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
+        };
+
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            normalized_config(topic),
+            record_batch_002,
+        )
+        .await?;
+        let pretty_results = pretty_format_batches(&results)?.to_string();
+
+        let expected = vec![
+            "+----------------+---------------------+-----------+------------+----------+---------------------+-----------------+",
+            "| meta.partition | meta.timestamp      | meta.year | meta.month | meta.day | value.email_address | value.full_name |",
+            "+----------------+---------------------+-----------+------------+----------+---------------------+-----------------+",
+            "| 32123          | 1973-10-17T18:36:57 | 1973      | 10         | 17       | lorem               | ipsum           |",
+            "| 32123          | 1973-10-17T18:36:57 | 1973      | 10         | 17       | lorem               |                 |",
+            "+----------------+---------------------+-----------+------------+----------+---------------------+-----------------+",
+        ];
+
+        assert_eq!(pretty_results.trim().lines().collect::<Vec<_>>(), expected);
+
+        let record_batch_003 = {
+            let schema = Schema::try_from(Bytes::from_static(include_bytes!("migrate-003.proto")))?;
+
+            Batch::builder()
+                .record(schema.generate()?)
+                .base_timestamp(119_731_017_000)
+                .build()
+                .map_err(Into::into)
+                .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
+        };
+
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            normalized_config(topic),
+            record_batch_003,
+        )
+        .await?;
+        let pretty_results = pretty_format_batches(&results)?.to_string();
+
+        let expected = vec![
+            "+----------------+---------------------+-----------+------------+----------+---------------------+-----------------+----------------------------+------------------------+-----------------+----------------------+-------------------------+--------------------+",
+            "| meta.partition | meta.timestamp      | meta.year | meta.month | meta.day | value.email_address | value.full_name | value.home.building_number | value.home.street_name | value.home.city | value.home.post_code | value.home.country_name | value.industry     |",
+            "+----------------+---------------------+-----------+------------+----------+---------------------+-----------------+----------------------------+------------------------+-----------------+----------------------+-------------------------+--------------------+",
+            "| 32123          | 1973-10-17T18:36:57 | 1973      | 10         | 17       | lorem               | ipsum           | dolor                      | sit                    | amet            | consectetur          | adipiscing              | [elit, elit, elit] |",
+            "| 32123          | 1973-10-17T18:36:57 | 1973      | 10         | 17       | lorem               | ipsum           |                            |                        |                 |                      |                         |                    |",
+            "| 32123          | 1973-10-17T18:36:57 | 1973      | 10         | 17       | lorem               |                 |                            |                        |                 |                      |                         |                    |",
+            "+----------------+---------------------+-----------+------------+----------+---------------------+-----------------+----------------------------+------------------------+-----------------+----------------------+-------------------------+--------------------+",
         ];
 
         assert_eq!(pretty_results.trim().lines().collect::<Vec<_>>(), expected);
@@ -1059,8 +1279,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -1147,8 +1375,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -1200,8 +1436,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -1260,8 +1504,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -1324,8 +1576,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -1376,8 +1636,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -1428,8 +1696,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -1505,8 +1781,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -1566,8 +1850,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -1629,8 +1921,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -1690,8 +1990,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -1754,8 +2062,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -1818,8 +2134,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -1882,8 +2206,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -1967,8 +2299,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -2031,8 +2371,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -2099,8 +2447,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -2161,8 +2517,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -2222,8 +2586,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -2284,8 +2656,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 
@@ -2345,8 +2725,16 @@ mod avro {
                 .and_then(|batch| schema.as_arrow(partition, &batch, LakeHouseType::Iceberg))?
         };
 
+        let namespace = &alphanumeric_string(5);
         let topic = &alphanumeric_string(5);
-        let results = lake_store(topic, partition, empty_config(topic), record_batch).await?;
+        let results = lake_store(
+            namespace,
+            topic,
+            partition,
+            empty_config(topic),
+            record_batch,
+        )
+        .await?;
 
         let pretty_results = pretty_format_batches(&results).map(|pretty| pretty.to_string())?;
 

--- a/tansu-schema/tests/migrate-001.proto
+++ b/tansu-schema/tests/migrate-001.proto
@@ -1,0 +1,47 @@
+// Copyright ⓒ 2024-2025 Peter Morgan <peter.james.morgan@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = 'proto3';
+
+import "google/protobuf/descriptor.proto";
+
+
+extend google.protobuf.FieldOptions {
+  Generator generate = 51215;
+}
+
+message Generator {
+    oneof apply {
+        bool skip = 1;
+        string script = 2;
+        Repeated repeated = 3;
+    }
+}
+
+message Repeated {
+    oneof size {
+        uint32 len = 1;
+        Range range = 2;
+    }
+    string script = 3;
+}
+
+message Range {
+    uint32 min = 1;
+    uint32 max = 2;
+}
+
+message Value {
+    string email_address = 1 [(generate).script = "\"lorem\""];
+}

--- a/tansu-schema/tests/migrate-002.proto
+++ b/tansu-schema/tests/migrate-002.proto
@@ -1,0 +1,48 @@
+// Copyright ⓒ 2024-2025 Peter Morgan <peter.james.morgan@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = 'proto3';
+
+import "google/protobuf/descriptor.proto";
+
+
+extend google.protobuf.FieldOptions {
+  Generator generate = 51215;
+}
+
+message Generator {
+    oneof apply {
+        bool skip = 1;
+        string script = 2;
+        Repeated repeated = 3;
+    }
+}
+
+message Repeated {
+    oneof size {
+        uint32 len = 1;
+        Range range = 2;
+    }
+    string script = 3;
+}
+
+message Range {
+    uint32 min = 1;
+    uint32 max = 2;
+}
+
+message Value {
+    string email_address = 1 [(generate).script = "\"lorem\""];
+    string full_name = 2 [(generate).script = "\"ipsum\""];
+}

--- a/tansu-schema/tests/migrate-003.proto
+++ b/tansu-schema/tests/migrate-003.proto
@@ -1,0 +1,58 @@
+// Copyright ⓒ 2024-2025 Peter Morgan <peter.james.morgan@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = 'proto3';
+
+import "google/protobuf/descriptor.proto";
+
+
+extend google.protobuf.FieldOptions {
+  Generator generate = 51215;
+}
+
+message Generator {
+    oneof apply {
+        bool skip = 1;
+        string script = 2;
+        Repeated repeated = 3;
+    }
+}
+
+message Repeated {
+    oneof size {
+        uint32 len = 1;
+        Range range = 2;
+    }
+    string script = 3;
+}
+
+message Range {
+    uint32 min = 1;
+    uint32 max = 2;
+}
+
+message Address {
+    string building_number = 1 [(generate).script = "\"dolor\""];
+    string street_name = 2 [(generate).script = "\"sit\""];
+    string city = 3 [(generate).script = "\"amet\""];
+    string post_code = 4 [(generate).script = "\"consectetur\""];
+    string country_name = 5 [(generate).script = "\"adipiscing\""];
+}
+
+message Value {
+    string email_address = 1 [(generate).script = "\"lorem\""];
+    string full_name = 2 [(generate).script = "\"ipsum\""];
+    Address home = 3;
+    repeated string industry = 4 [(generate).repeated = {script: "\"elit\"", len: 3}];
+}


### PR DESCRIPTION
This change adds configurable cache expiration to the schema registry and includes related cleanups:

- Introduce Registry builder pattern for better configuration - Move metrics to lazy statics to avoid recreation - Handle schema evolution/migration in the Delta lake backend - Fix schema registry handling in broker and CLI interfaces

The expiration feature helps prevent stale schemas from persisting in memory indefinitely.