### PR TITLE
Ping the storage backend on initialization #273

### DIFF
--- a/tansu-storage/src/dynostore.rs
+++ b/tansu-storage/src/dynostore.rs
@@ -2662,6 +2662,13 @@ impl Storage for DynoStore {
     async fn advertised_listener(&self) -> Result<Url> {
         Ok(self.advertised_listener.clone())
     }
+
+    #[instrument(skip_all)]
+    async fn ping(&self) -> Result<()> {
+        // Verify connectivity by listing objects at the root
+        let _ = self.object_store.list(Some(&Path::from("/"))).next().await;
+        Ok(())
+    }
 }
 
 fn object_store_error_name(error: &object_store::Error) -> &'static str {

--- a/tansu-storage/src/limbo.rs
+++ b/tansu-storage/src/limbo.rs
@@ -3641,6 +3641,12 @@ impl Storage for Engine {
     async fn advertised_listener(&self) -> Result<Url> {
         Ok(self.advertised_listener.clone())
     }
+
+    async fn ping(&self) -> Result<()> {
+        let c = self.connection().await?;
+        let _ = c.query("ping.sql", ()).await?;
+        Ok(())
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/tansu-storage/src/null.rs
+++ b/tansu-storage/src/null.rs
@@ -507,4 +507,9 @@ impl Storage for Engine {
     async fn advertised_listener(&self) -> Result<Url> {
         Ok(self.advertised_listener.clone())
     }
+
+    #[instrument(skip_all)]
+    async fn ping(&self) -> Result<()> {
+        Ok(())
+    }
 }

--- a/tansu-storage/src/pg.rs
+++ b/tansu-storage/src/pg.rs
@@ -3428,6 +3428,13 @@ impl Storage for Postgres {
     async fn advertised_listener(&self) -> Result<Url> {
         Ok(self.advertised_listener.clone())
     }
+
+    #[instrument(skip_all)]
+    async fn ping(&self) -> Result<()> {
+        let c = self.pool.get().await?;
+        let _ = self.prepare_query(&c, "ping.sql", &[]).await?;
+        Ok(())
+    }
 }
 
 static SQL_DURATION: LazyLock<Histogram<u64>> = LazyLock::new(|| {

--- a/tansu-storage/src/sql.rs
+++ b/tansu-storage/src/sql.rs
@@ -137,6 +137,7 @@ pub(crate) static SQL: LazyLock<Cache> = LazyLock::new(|| {
             "list_latest_offset_uncommitted.sql",
             include_sql!("pg/list_latest_offset_uncommitted.sql"),
         ),
+        ("ping.sql", "select 1 + 1".to_string()),
         (
             "producer_detail_delete_by_topic.sql",
             include_sql!("pg/producer_detail_delete_by_topic.sql"),


### PR DESCRIPTION
Addressing the point brought up in #273 when the tansu broker is initialized even though the storage backend is "unavailable".