### PR TITLE
readme: add link to blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ stateless Kafka-compatible broker with pluggable storage (PostgreSQL, SQLite, S3
 
 [![License](https://img.shields.io/badge/License-Apache-165dfc.svg)](https://github.com/tansu-io/tansu/blob/main/LICENSE)
 &nbsp;
+[![Built with Rust](https://img.shields.io/badge/built_with-Rust-165dfc.svg?logo=rust)](https://www.rust-lang.org/)
+&nbsp;
+<br>
 [![Docs](https://img.shields.io/badge/📖%20docs-docs.tansu.io-165dfc.svg)](https://docs.tansu.io/)
 &nbsp;
-[![Built with Rust](https://img.shields.io/badge/built_with-Rust-165dfc.svg?logo=rust)](https://www.rust-lang.org/)
+[![Blog](https://img.shields.io/badge/%F0%9F%93%98%20blog-blog.tansu.io-165dfc.svg)](https://blog.tansu.io/articles)
 &nbsp;
 <br>
 [![GitHub stars](https://img.shields.io/github/stars/tansu-io/tansu?style=social)](https://github.com/tansu-io/tansu)


### PR DESCRIPTION
following up on the last PR pretty-fying the readme - I thought it ought to have a link to the blog too
