### PR TITLE
Add ICEBERG_ vars to example env

### DIFF
--- a/example.env
+++ b/example.env
@@ -46,3 +46,6 @@ STORAGE_ENGINE="s3://tansu/"
 #STORAGE_ENGINE="postgres://postgres:postgres@localhost"
 
 LAKEKEEPER_IMAGE="quay.io/lakekeeper/catalog:v0.8.5"
+
+ICEBERG_CATALOG="http://localhost:8181/catalog"
+ICEBERG_WAREHOUSE="tansu"


### PR DESCRIPTION
Given: A fresh clone of tansu and copy the example.env to .env
When: I run `just ci && just test`
Then: Tests should pass

Today the berg tests fail because it thinks the catalog endpoint is localhost:8181 but it's actually at localhost:8181/catalog and the ICEBERG_WAREHOUSE doesn't have a default in the code (which makes sense ofc)

```
---- lake::berg::tests::create_duplicate_table stdout ----
Error: Iceberg(Unexpected => Received response with unexpected status code

Context:
   status: 404 Not Found
   headers: {"x-request-id": "019baec5-365d-7360-85df-56b29d3b9543", "content-length": "0", "date": "Sun, 11 Jan 2026 20:35:18 GMT"}
```
and if you manage to connect by adding this env var you get 
```
---- lake::berg::tests::create_namespace stdout ----
Error: Iceberg(Unexpected => Received response with unexpected status code

Context:
   status: 400 Bad Request
   headers: {"content-type": "application/json", "x-request-id": "019baed3-eb50-7142-b403-ed147bd0d0e7", "vary": "accept-encoding", "content-length": "214", "date": "Sun, 11 Jan 2026 20:51:22 GMT"}
   json: {"error":{"message":"No warehouse specified. Please specify the 'warehouse' parameter in the GET /config request.","type":"GetConfigNoWarehouseProvided","code":400,"stack":["019baed3-eb50-7142-b403-ed32b630e139"]}}
```

This change mimics the env vars set explicitly in the github actions ci workflow.
