### PR TITLE
virtual keyed topics: filter fetch by key when topic name contains '/'

### DIFF
--- a/tansu-broker/tests/produce_fetch.rs
+++ b/tansu-broker/tests/produce_fetch.rs
@@ -605,6 +605,116 @@ where
     Ok(())
 }
 
+pub async fn virtual_keyed_topic_fetch<G>(
+    cluster_id: impl Into<String>,
+    broker_id: i32,
+    sc: G,
+) -> Result<()>
+where
+    G: Storage + Clone,
+{
+    register_broker(cluster_id, broker_id, sc.clone()).await?;
+
+    let topic_name: String = alphanumeric_string(15);
+    debug!(?topic_name);
+
+    let partition = 0;
+    let transaction_timeout_ms = 10_000;
+
+    let topic_id = sc
+        .create_topic(
+            CreatableTopic::default()
+                .name(topic_name.clone())
+                .num_partitions(1)
+                .replication_factor(0)
+                .assignments(Some([].into()))
+                .configs(Some([].into())),
+            false,
+        )
+        .await?;
+    debug!(?topic_id);
+
+    let topition = Topition::new(topic_name.clone(), partition);
+
+    const KEY_A: &[u8] = b"CC54 RYD";
+    const KEY_B: &[u8] = b"NN03 RYB";
+
+    for (key, value) in [
+        (KEY_A, b"telemetry a1" as &[u8]),
+        (KEY_B, b"telemetry b1"),
+        (KEY_A, b"telemetry a2"),
+        (KEY_B, b"telemetry b2"),
+        (KEY_A, b"telemetry a3"),
+        (KEY_B, b"telemetry b3"),
+    ] {
+        let producer = sc
+            .init_producer(None, transaction_timeout_ms, Some(-1), Some(-1))
+            .await?;
+
+        let batch = inflated::Batch::builder()
+            .record(
+                Record::builder()
+                    .key(Some(Bytes::copy_from_slice(key)))
+                    .value(Some(Bytes::copy_from_slice(value))),
+            )
+            .producer_id(producer.id)
+            .producer_epoch(producer.epoch)
+            .build()
+            .and_then(TryInto::try_into)?;
+
+        let offset = sc.produce(None, &topition, batch).await?;
+        debug!(offset);
+    }
+
+    let offset = 0;
+    let min_bytes = 1;
+    let max_bytes = 50 * 1_024;
+    let isolation = IsolationLevel::ReadUncommitted;
+
+    let collect_records = |batches: Vec<tansu_sans_io::record::deflated::Batch>| {
+        batches.into_iter().try_fold(Vec::new(), |mut acc, batch| {
+            inflated::Batch::try_from(batch).map(|inflated| {
+                acc.extend(inflated.records);
+                acc
+            })
+        })
+    };
+
+    // Fetch the base topic — all six records
+    let all_records = sc
+        .fetch(&topition, offset, min_bytes, max_bytes, isolation)
+        .await
+        .and_then(|batches| collect_records(batches).map_err(Into::into))?;
+    debug!(?all_records);
+    assert_eq!(6, all_records.len());
+
+    // Fetch virtual keyed topic for KEY_A — three records
+    let keyed_topition_a = Topition::new(format!("{topic_name}/CC54 RYD"), partition);
+    let key_a_records = sc
+        .fetch(&keyed_topition_a, offset, min_bytes, max_bytes, isolation)
+        .await
+        .and_then(|batches| collect_records(batches).map_err(Into::into))?;
+    debug!(?key_a_records);
+    assert_eq!(3, key_a_records.len());
+    for record in &key_a_records {
+        assert_eq!(Some(Bytes::from_static(KEY_A)), record.key);
+    }
+
+    // Fetch virtual keyed topic for KEY_B — three records
+    let keyed_topition_b = Topition::new(format!("{topic_name}/NN03 RYB"), partition);
+    let key_b_records = sc
+        .fetch(&keyed_topition_b, offset, min_bytes, max_bytes, isolation)
+        .await
+        .and_then(|batches| collect_records(batches).map_err(Into::into))?;
+    debug!(?key_b_records);
+    assert_eq!(3, key_b_records.len());
+    for record in &key_b_records {
+        assert_eq!(Some(Bytes::from_static(KEY_B)), record.key);
+    }
+
+    Ok(())
+}
+
 #[cfg(feature = "postgres")]
 mod pg {
     use std::sync::Arc;
@@ -663,6 +773,21 @@ mod pg {
         let broker_id = rng().random_range(0..i32::MAX);
 
         super::with_multiple_txn(
+            cluster_id,
+            broker_id,
+            storage_container(cluster_id, broker_id).await?,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn virtual_keyed_topic_fetch() -> Result<()> {
+        let _guard = init_tracing()?;
+
+        let cluster_id = Uuid::now_v7();
+        let broker_id = rng().random_range(0..i32::MAX);
+
+        super::virtual_keyed_topic_fetch(
             cluster_id,
             broker_id,
             storage_container(cluster_id, broker_id).await?,
@@ -795,6 +920,21 @@ mod lite {
         let broker_id = rng().random_range(0..i32::MAX);
 
         super::with_multiple_txn(
+            cluster_id,
+            broker_id,
+            storage_container(cluster_id, broker_id).await?,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn virtual_keyed_topic_fetch() -> Result<()> {
+        let _guard = init_tracing()?;
+
+        let cluster_id = Uuid::now_v7();
+        let broker_id = rng().random_range(0..i32::MAX);
+
+        super::virtual_keyed_topic_fetch(
             cluster_id,
             broker_id,
             storage_container(cluster_id, broker_id).await?,

--- a/tansu-broker/tests/produce_fetch.rs
+++ b/tansu-broker/tests/produce_fetch.rs
@@ -24,7 +24,7 @@ use tansu_sans_io::{
     add_partitions_to_txn_response::{
         AddPartitionsToTxnPartitionResult, AddPartitionsToTxnTopicResult,
     },
-    create_topics_request::CreatableTopic,
+    create_topics_request::{CreatableTopic, CreatableTopicConfig},
     record::{Record, inflated},
 };
 use tansu_storage::{Storage, Topition, TxnAddPartitionsRequest};
@@ -628,7 +628,12 @@ where
                 .num_partitions(1)
                 .replication_factor(0)
                 .assignments(Some([].into()))
-                .configs(Some([].into())),
+                .configs(Some(
+                    [CreatableTopicConfig::default()
+                        .name("tansu.virtual".into())
+                        .value(Some("true".into()))]
+                    .into(),
+                )),
             false,
         )
         .await?;

--- a/tansu-broker/tests/produce_fetch.rs
+++ b/tansu-broker/tests/produce_fetch.rs
@@ -720,6 +720,95 @@ where
     Ok(())
 }
 
+pub async fn non_virtual_topic_with_slash_streams_all<G>(
+    cluster_id: impl Into<String>,
+    broker_id: i32,
+    sc: G,
+) -> Result<()>
+where
+    G: Storage + Clone,
+{
+    register_broker(cluster_id, broker_id, sc.clone()).await?;
+
+    // Topic name contains "/" but tansu.virtual is NOT set — the slash is just
+    // part of the topic name, not a key filter.
+    let topic_name: String = format!("{}/{}", alphanumeric_string(10), alphanumeric_string(5));
+    debug!(?topic_name);
+
+    let partition = 0;
+    let transaction_timeout_ms = 10_000;
+
+    let topic_id = sc
+        .create_topic(
+            CreatableTopic::default()
+                .name(topic_name.clone())
+                .num_partitions(1)
+                .replication_factor(0)
+                .assignments(Some([].into()))
+                .configs(Some([].into())),
+            false,
+        )
+        .await?;
+    debug!(?topic_id);
+
+    let topition = Topition::new(topic_name.clone(), partition);
+
+    const KEY_A: &[u8] = b"CC54 RYD";
+    const KEY_B: &[u8] = b"NN03 RYB";
+
+    for (key, value) in [
+        (KEY_A, b"telemetry a1" as &[u8]),
+        (KEY_B, b"telemetry b1"),
+        (KEY_A, b"telemetry a2"),
+        (KEY_B, b"telemetry b2"),
+        (KEY_A, b"telemetry a3"),
+        (KEY_B, b"telemetry b3"),
+    ] {
+        let producer = sc
+            .init_producer(None, transaction_timeout_ms, Some(-1), Some(-1))
+            .await?;
+
+        let batch = inflated::Batch::builder()
+            .record(
+                Record::builder()
+                    .key(Some(Bytes::copy_from_slice(key)))
+                    .value(Some(Bytes::copy_from_slice(value))),
+            )
+            .producer_id(producer.id)
+            .producer_epoch(producer.epoch)
+            .build()
+            .and_then(TryInto::try_into)?;
+
+        let offset = sc.produce(None, &topition, batch).await?;
+        debug!(offset);
+    }
+
+    let offset = 0;
+    let min_bytes = 1;
+    let max_bytes = 50 * 1_024;
+    let isolation = IsolationLevel::ReadUncommitted;
+
+    let collect_records = |batches: Vec<tansu_sans_io::record::deflated::Batch>| {
+        batches.into_iter().try_fold(Vec::new(), |mut acc, batch| {
+            inflated::Batch::try_from(batch).map(|inflated| {
+                acc.extend(inflated.records);
+                acc
+            })
+        })
+    };
+
+    // All six records are returned — tansu.virtual is not set so the "/" is
+    // treated as part of the topic name with no key filtering applied.
+    let all_records = sc
+        .fetch(&topition, offset, min_bytes, max_bytes, isolation)
+        .await
+        .and_then(|batches| collect_records(batches).map_err(Into::into))?;
+    debug!(?all_records);
+    assert_eq!(6, all_records.len());
+
+    Ok(())
+}
+
 #[cfg(feature = "postgres")]
 mod pg {
     use std::sync::Arc;
@@ -793,6 +882,21 @@ mod pg {
         let broker_id = rng().random_range(0..i32::MAX);
 
         super::virtual_keyed_topic_fetch(
+            cluster_id,
+            broker_id,
+            storage_container(cluster_id, broker_id).await?,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn non_virtual_topic_with_slash_streams_all() -> Result<()> {
+        let _guard = init_tracing()?;
+
+        let cluster_id = Uuid::now_v7();
+        let broker_id = rng().random_range(0..i32::MAX);
+
+        super::non_virtual_topic_with_slash_streams_all(
             cluster_id,
             broker_id,
             storage_container(cluster_id, broker_id).await?,
@@ -940,6 +1044,21 @@ mod lite {
         let broker_id = rng().random_range(0..i32::MAX);
 
         super::virtual_keyed_topic_fetch(
+            cluster_id,
+            broker_id,
+            storage_container(cluster_id, broker_id).await?,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn non_virtual_topic_with_slash_streams_all() -> Result<()> {
+        let _guard = init_tracing()?;
+
+        let cluster_id = Uuid::now_v7();
+        let broker_id = rng().random_range(0..i32::MAX);
+
+        super::non_virtual_topic_with_slash_streams_all(
             cluster_id,
             broker_id,
             storage_container(cluster_id, broker_id).await?,

--- a/tansu-storage/src/lite.rs
+++ b/tansu-storage/src/lite.rs
@@ -2327,13 +2327,30 @@ impl Storage for Delegate {
 
         debug!(?topition, offset, min_bytes, max_bytes, ?isolation_level);
 
-        let high_watermark = self.offset_stage(topition).await.map(|offset_stage| {
-            if isolation_level == IsolationLevel::ReadCommitted {
-                offset_stage.last_stable
-            } else {
-                offset_stage.high_watermark
-            }
-        })?;
+        let (base_topic, key_filter): (&str, Option<&str>) = topition
+            .topic()
+            .split_once('/')
+            .map(|(t, k)| (t, Some(k)))
+            .unwrap_or((topition.topic(), None));
+
+        let base_topition;
+        let effective_topition: &Topition = if key_filter.is_some() {
+            base_topition = Topition::new(base_topic, topition.partition());
+            &base_topition
+        } else {
+            topition
+        };
+
+        let high_watermark = self
+            .offset_stage(effective_topition)
+            .await
+            .map(|offset_stage| {
+                if isolation_level == IsolationLevel::ReadCommitted {
+                    offset_stage.last_stable
+                } else {
+                    offset_stage.high_watermark
+                }
+            })?;
 
         debug!(
             cluster = self.cluster,
@@ -2347,8 +2364,24 @@ impl Storage for Delegate {
 
         let c = self.connection().await?;
 
-        let mut records = c
-            .query(
+        let mut records = if let Some(key) = key_filter {
+            let key_bytes = key.as_bytes().to_vec();
+            c.query(
+                "record_fetch_keyed.sql",
+                (
+                    self.cluster.as_str(),
+                    base_topic,
+                    topition.partition(),
+                    offset,
+                    (max_bytes as i64),
+                    high_watermark,
+                    key_bytes,
+                ),
+            )
+            .await
+            .inspect_err(|err| error!(?err))?
+        } else {
+            c.query(
                 "record_fetch.sql",
                 (
                     self.cluster.as_str(),
@@ -2360,7 +2393,8 @@ impl Storage for Delegate {
                 ),
             )
             .await
-            .inspect_err(|err| error!(?err))?;
+            .inspect_err(|err| error!(?err))?
+        };
 
         let mut batches = vec![];
 

--- a/tansu-storage/src/lite.rs
+++ b/tansu-storage/src/lite.rs
@@ -2327,11 +2327,34 @@ impl Storage for Delegate {
 
         debug!(?topition, offset, min_bytes, max_bytes, ?isolation_level);
 
-        let (base_topic, key_filter): (&str, Option<&str>) = topition
-            .topic()
-            .split_once('/')
-            .map(|(t, k)| (t, Some(k)))
-            .unwrap_or((topition.topic(), None));
+        let (base_topic, key_filter): (&str, Option<&str>) =
+            if let Some((t, k)) = topition.topic().split_once('/') {
+                let is_virtual = self
+                    .describe_config(t, ConfigResource::Topic, None)
+                    .await
+                    .map(|result| {
+                        result
+                            .configs
+                            .as_ref()
+                            .and_then(|configs| {
+                                configs
+                                    .iter()
+                                    .find(|c| c.name.as_str() == "tansu.virtual")
+                                    .and_then(|c| c.value.as_deref())
+                                    .and_then(|v| bool::from_str(v).ok())
+                            })
+                            .unwrap_or_default()
+                    })
+                    .unwrap_or_default();
+
+                if is_virtual {
+                    (t, Some(k))
+                } else {
+                    (topition.topic(), None)
+                }
+            } else {
+                (topition.topic(), None)
+            };
 
         let base_topition;
         let effective_topition: &Topition = if key_filter.is_some() {

--- a/tansu-storage/src/pg.rs
+++ b/tansu-storage/src/pg.rs
@@ -1744,13 +1744,30 @@ impl Storage for Postgres {
         max_bytes: u32,
         isolation_level: IsolationLevel,
     ) -> Result<Vec<deflated::Batch>> {
-        let high_watermark = self.offset_stage(topition).await.map(|offset_stage| {
-            if isolation_level == IsolationLevel::ReadCommitted {
-                offset_stage.last_stable
-            } else {
-                offset_stage.high_watermark
-            }
-        })?;
+        let (base_topic, key_filter): (&str, Option<&str>) = topition
+            .topic()
+            .split_once('/')
+            .map(|(t, k)| (t, Some(k)))
+            .unwrap_or((topition.topic(), None));
+
+        let base_topition;
+        let effective_topition: &Topition = if key_filter.is_some() {
+            base_topition = Topition::new(base_topic, topition.partition());
+            &base_topition
+        } else {
+            topition
+        };
+
+        let high_watermark = self
+            .offset_stage(effective_topition)
+            .await
+            .map(|offset_stage| {
+                if isolation_level == IsolationLevel::ReadCommitted {
+                    offset_stage.last_stable
+                } else {
+                    offset_stage.high_watermark
+                }
+            })?;
 
         debug!(
             cluster = self.cluster,
@@ -1765,8 +1782,25 @@ impl Storage for Postgres {
         let mut c = self.connection().await?;
         let tx = c.transaction().await?;
 
-        let records = self
-            .tx_prepare_query(
+        let records = if let Some(key) = key_filter {
+            let key_bytes = key.as_bytes().to_vec();
+            self.tx_prepare_query(
+                &tx,
+                "record_fetch_pg_keyed.sql",
+                &[
+                    &self.cluster,
+                    &base_topic,
+                    &topition.partition(),
+                    &offset,
+                    &(max_bytes as i64),
+                    &high_watermark,
+                    &key_bytes,
+                ],
+            )
+            .await
+            .inspect_err(|err| error!(?err))?
+        } else {
+            self.tx_prepare_query(
                 &tx,
                 "record_fetch_pg.sql",
                 &[
@@ -1779,7 +1813,8 @@ impl Storage for Postgres {
                 ],
             )
             .await
-            .inspect_err(|err| error!(?err))?;
+            .inspect_err(|err| error!(?err))?
+        };
 
         let mut batches = vec![];
 

--- a/tansu-storage/src/pg.rs
+++ b/tansu-storage/src/pg.rs
@@ -1744,11 +1744,34 @@ impl Storage for Postgres {
         max_bytes: u32,
         isolation_level: IsolationLevel,
     ) -> Result<Vec<deflated::Batch>> {
-        let (base_topic, key_filter): (&str, Option<&str>) = topition
-            .topic()
-            .split_once('/')
-            .map(|(t, k)| (t, Some(k)))
-            .unwrap_or((topition.topic(), None));
+        let (base_topic, key_filter): (&str, Option<&str>) =
+            if let Some((t, k)) = topition.topic().split_once('/') {
+                let is_virtual = self
+                    .describe_config(t, ConfigResource::Topic, None)
+                    .await
+                    .map(|result| {
+                        result
+                            .configs
+                            .as_ref()
+                            .and_then(|configs| {
+                                configs
+                                    .iter()
+                                    .find(|c| c.name.as_str() == "tansu.virtual")
+                                    .and_then(|c| c.value.as_deref())
+                                    .and_then(|v| bool::from_str(v).ok())
+                            })
+                            .unwrap_or_default()
+                    })
+                    .unwrap_or_default();
+
+                if is_virtual {
+                    (t, Some(k))
+                } else {
+                    (topition.topic(), None)
+                }
+            } else {
+                (topition.topic(), None)
+            };
 
         let base_topition;
         let effective_topition: &Topition = if key_filter.is_some() {

--- a/tansu-storage/src/pg/record_fetch_keyed.sql
+++ b/tansu-storage/src/pg/record_fetch_keyed.sql
@@ -1,0 +1,47 @@
+-- -*- mode: sql; sql-product: postgres; -*-
+-- Copyright ⓒ 2024-2026 Peter Morgan <peter.james.morgan@gmail.com>
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- prepare record_fetch_keyed (text, text, integer, integer, integer, integer, bytea) as
+with sized as (
+select
+
+r.offset_id,
+r.attributes,
+r.timestamp,
+r.k,
+r.v,
+sum(coalesce(length(r.k), 0) + coalesce(length(r.v), 0)) over (order by r.offset_id) as bytes,
+r.producer_id,
+r.producer_epoch,
+r.transaction_id < pg_snapshot_xmin(pg_current_snapshot())
+
+from
+
+cluster c
+join topic t on t.cluster = c.id
+join topition tp on tp.topic = t.id
+join record r on r.topition = tp.id
+
+where
+
+c.name = $1
+and t.name = $2
+and tp.partition = $3
+and r.offset_id >= $4
+-- and r.transaction_id < pg_snapshot_xmin(pg_current_snapshot())
+and r.offset_id < $6
+and r.k = $7)
+
+select * from sized where bytes < $5;

--- a/tansu-storage/src/sql.rs
+++ b/tansu-storage/src/sql.rs
@@ -191,7 +191,15 @@ pub(crate) static SQL: LazyLock<Cache> = LazyLock::new(|| {
             include_sql!("sql/record_delete_by_topic.sql"),
         ),
         ("record_fetch.sql", include_sql!("sql/record_fetch.sql")),
+        (
+            "record_fetch_keyed.sql",
+            include_sql!("sql/record_fetch_keyed.sql"),
+        ),
         ("record_fetch_pg.sql", include_sql!("pg/record_fetch.sql")),
+        (
+            "record_fetch_pg_keyed.sql",
+            include_sql!("pg/record_fetch_keyed.sql"),
+        ),
         ("record_insert.sql", include_sql!("sql/record_insert.sql")),
         (
             "register_broker.sql",

--- a/tansu-storage/src/sql/record_fetch_keyed.sql
+++ b/tansu-storage/src/sql/record_fetch_keyed.sql
@@ -1,0 +1,45 @@
+-- -*- mode: sql; sql-product: postgres; -*-
+-- Copyright ⓒ 2024-2026 Peter Morgan <peter.james.morgan@gmail.com>
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- prepare record_fetch_keyed (text, text, integer, integer, integer, integer, blob) as
+with sized as (
+select
+
+r.offset_id,
+r.attributes,
+r.timestamp,
+r.k,
+r.v,
+sum(coalesce(length(r.k), 0) + coalesce(length(r.v), 0)) over (order by r.offset_id) as bytes,
+r.producer_id,
+r.producer_epoch
+
+from
+
+cluster c
+join topic t on t.cluster = c.id
+join topition tp on tp.topic = t.id
+join record r on r.topition = tp.id
+
+where
+
+c.name = $1
+and t.name = $2
+and tp.partition = $3
+and r.offset_id >= $4
+and r.offset_id < $6
+and r.k = $7)
+
+select * from sized where bytes < $5;


### PR DESCRIPTION
A fetch on `topic/key` now returns only records where the stored key matches the UTF-8 bytes of the key portion, while `offset_stage` is resolved against the base topic's watermark.  Both the Postgres and libSQL backends gain a companion `record_fetch_{pg_,}keyed.sql` that adds `AND r.k = $7` to the existing fetch query.