### PR TITLE
fix(storage): parse GroupDetail JSON instead of wrapping it as Value::String

### DIFF
--- a/tansu-storage/src/limbo.rs
+++ b/tansu-storage/src/limbo.rs
@@ -2909,7 +2909,7 @@ impl Storage for Engine {
                     .await
                     .inspect_err(|err| error!(?err, group_id))?
                 {
-                    let value = row
+                    let current = row
                         .get_value(1)
                         .map_err(Error::from)
                         .and_then(|value| {
@@ -2918,11 +2918,11 @@ impl Storage for Engine {
                                 .cloned()
                                 .ok_or(Error::UnexpectedValue(value.clone()))
                         })
-                        .map(serde_json::Value::from)
+                        .and_then(|s| {
+                            serde_json::from_str::<GroupDetail>(&s).map_err(Into::into)
+                        })
+                        .inspect(|current| debug!(?current))
                         .inspect_err(|err| error!(?err, group_id))?;
-
-                    let current = serde_json::from_value::<GroupDetail>(value)
-                        .inspect(|current| debug!(?current))?;
 
                     results.push(NamedGroupDetail::found(group_id.into(), current));
                 } else {
@@ -3037,15 +3037,18 @@ impl Storage for Engine {
                 })
                 .inspect(|version| debug!(?version))?;
 
-            let value = row.get_value(1).map_err(Error::from).and_then(|value| {
-                value
-                    .as_text()
-                    .map(|v| v.as_str())
-                    .ok_or(Error::UnexpectedValue(value.clone()))
-                    .map(serde_json::Value::from)
-            })?;
-
-            let current = serde_json::from_value::<GroupDetail>(value)
+            let current = row
+                .get_value(1)
+                .map_err(Error::from)
+                .and_then(|value| {
+                    value
+                        .as_text()
+                        .map(|v| v.as_str())
+                        .ok_or(Error::UnexpectedValue(value.clone()))
+                        .and_then(|s| {
+                            serde_json::from_str::<GroupDetail>(s).map_err(Into::into)
+                        })
+                })
                 .inspect(|current| debug!(?current))
                 .map(Box::new)?;
 

--- a/tansu-storage/src/limbo.rs
+++ b/tansu-storage/src/limbo.rs
@@ -2918,9 +2918,7 @@ impl Storage for Engine {
                                 .cloned()
                                 .ok_or(Error::UnexpectedValue(value.clone()))
                         })
-                        .and_then(|s| {
-                            serde_json::from_str::<GroupDetail>(&s).map_err(Into::into)
-                        })
+                        .and_then(|s| serde_json::from_str::<GroupDetail>(&s).map_err(Into::into))
                         .inspect(|current| debug!(?current))
                         .inspect_err(|err| error!(?err, group_id))?;
 
@@ -3045,9 +3043,7 @@ impl Storage for Engine {
                         .as_text()
                         .map(|v| v.as_str())
                         .ok_or(Error::UnexpectedValue(value.clone()))
-                        .and_then(|s| {
-                            serde_json::from_str::<GroupDetail>(s).map_err(Into::into)
-                        })
+                        .and_then(|s| serde_json::from_str::<GroupDetail>(s).map_err(Into::into))
                 })
                 .inspect(|current| debug!(?current))
                 .map(Box::new)?;

--- a/tansu-storage/src/lite.rs
+++ b/tansu-storage/src/lite.rs
@@ -3960,14 +3960,14 @@ impl Storage for Delegate {
                     .await
                     .inspect_err(|err| error!(?err, group_id))?
                 {
-                    let value = row
+                    let current = row
                         .get_str(1)
                         .map_err(Error::from)
-                        .map(serde_json::Value::from)
+                        .and_then(|s| {
+                            serde_json::from_str::<GroupDetail>(s).map_err(Into::into)
+                        })
+                        .inspect(|current| debug!(?current))
                         .inspect_err(|err| error!(?err, group_id))?;
-
-                    let current = serde_json::from_value::<GroupDetail>(value)
-                        .inspect(|current| debug!(?current))?;
 
                     results.push(NamedGroupDetail::found(group_id.into(), current));
                 } else {

--- a/tansu-storage/src/lite.rs
+++ b/tansu-storage/src/lite.rs
@@ -3963,9 +3963,7 @@ impl Storage for Delegate {
                     let current = row
                         .get_str(1)
                         .map_err(Error::from)
-                        .and_then(|s| {
-                            serde_json::from_str::<GroupDetail>(s).map_err(Into::into)
-                        })
+                        .and_then(|s| serde_json::from_str::<GroupDetail>(s).map_err(Into::into))
                         .inspect(|current| debug!(?current))
                         .inspect_err(|err| error!(?err, group_id))?;
 

--- a/tansu-storage/tests/describe_groups_round_trip.rs
+++ b/tansu-storage/tests/describe_groups_round_trip.rs
@@ -24,7 +24,7 @@
 
 mod common;
 
-use std::{sync::Arc, thread};
+use std::{slice::from_ref, sync::Arc, thread};
 
 use rand::{prelude::*, rng};
 use tansu_storage::{BrokerRegistrationRequest, GroupDetail, Storage, StorageContainer};
@@ -90,7 +90,7 @@ async fn round_trip(scheme: &str) -> Result<(), Error> {
         .map_err(|err| Error::Message(format!("update_group: {err:?}")))?;
 
     let described = storage
-        .describe_groups(Some(&[group_id.clone()]), false)
+        .describe_groups(Some(from_ref(&group_id)), false)
         .await?;
 
     assert_eq!(1, described.len(), "describe_groups must return one entry");

--- a/tansu-storage/tests/describe_groups_round_trip.rs
+++ b/tansu-storage/tests/describe_groups_round_trip.rs
@@ -1,0 +1,117 @@
+// Copyright ⓒ 2024-2026 Peter Morgan <peter.james.morgan@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression test for `describe_groups` on the storage backends that
+//! persist `GroupDetail` as JSON text.
+//!
+//! Both the libsql (`lite.rs`) and turso (`limbo.rs`) backends used to
+//! call `serde_json::Value::from(&str)` on the JSON column, which wraps
+//! the raw JSON text as a `Value::String` instead of parsing it. The
+//! subsequent `serde_json::from_value::<GroupDetail>` then always
+//! failed with `invalid type: string "...", expected struct
+//! GroupDetail`. The native-JSON Postgres backend was not affected.
+
+mod common;
+
+use std::{sync::Arc, thread};
+
+use rand::{prelude::*, rng};
+use tansu_storage::{
+    BrokerRegistrationRequest, GroupDetail, Storage, StorageContainer,
+};
+use tracing::debug;
+use url::Url;
+use uuid::Uuid;
+
+use crate::common::{Error, init_tracing};
+
+fn storage_url(scheme: &str) -> Result<Url, Error> {
+    thread::current()
+        .name()
+        .ok_or_else(|| Error::Message("unnamed thread".into()))
+        .map(|name| {
+            format!(
+                "{scheme}://../logs/{}/{}::{name}.db",
+                env!("CARGO_PKG_NAME"),
+                env!("CARGO_CRATE_NAME"),
+            )
+        })
+        .and_then(|url| Url::parse(&url).map_err(Into::into))
+}
+
+async fn build_storage(
+    scheme: &str,
+    cluster: &str,
+    node: i32,
+) -> Result<Arc<Box<dyn Storage>>, Error> {
+    StorageContainer::builder()
+        .cluster_id(cluster)
+        .node_id(node)
+        .advertised_listener(Url::parse("tcp://127.0.0.1:9092")?)
+        .storage(storage_url(scheme)?)
+        .build()
+        .await
+        .map_err(Into::into)
+}
+
+async fn round_trip(scheme: &str) -> Result<(), Error> {
+    let _guard = init_tracing()?;
+
+    let cluster_id = Uuid::now_v7().to_string();
+    let node_id = rng().random_range(0..i32::MAX);
+    let group_id = format!("test-group-{}", Uuid::now_v7());
+
+    let storage = build_storage(scheme, &cluster_id, node_id).await?;
+
+    storage
+        .register_broker(BrokerRegistrationRequest {
+            broker_id: node_id,
+            cluster_id: cluster_id.clone(),
+            incarnation_id: Uuid::new_v4(),
+            rack: None,
+        })
+        .await?;
+
+    let detail = GroupDetail::default();
+
+    let _version = storage
+        .update_group(&group_id, detail.clone(), None)
+        .await
+        .inspect(|version| debug!(?version))
+        .map_err(|err| Error::Message(format!("update_group: {err:?}")))?;
+
+    let described = storage
+        .describe_groups(Some(&[group_id.clone()]), false)
+        .await?;
+
+    assert_eq!(1, described.len(), "describe_groups must return one entry");
+
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_describe_groups_round_trip() -> Result<(), Error> {
+    round_trip("sqlite").await
+}
+
+// The turso end-to-end harness is unstable (existing turso tests in
+// `tansu-broker` are all `#[ignore]`); run this by hand with
+// `cargo test --features turso -- --ignored` once the harness lands.
+#[cfg(feature = "turso")]
+#[ignore]
+#[tokio::test]
+async fn turso_describe_groups_round_trip() -> Result<(), Error> {
+    round_trip("turso").await
+}

--- a/tansu-storage/tests/describe_groups_round_trip.rs
+++ b/tansu-storage/tests/describe_groups_round_trip.rs
@@ -27,9 +27,7 @@ mod common;
 use std::{sync::Arc, thread};
 
 use rand::{prelude::*, rng};
-use tansu_storage::{
-    BrokerRegistrationRequest, GroupDetail, Storage, StorageContainer,
-};
+use tansu_storage::{BrokerRegistrationRequest, GroupDetail, Storage, StorageContainer};
 use tracing::debug;
 use url::Url;
 use uuid::Uuid;


### PR DESCRIPTION
## Summary

`describe_groups` (libsql/\`lite.rs\`) and \`update_group\` + \`describe_groups\` (turso/\`limbo.rs\`) called \`serde_json::Value::from(&str)\` on the JSON column read out of SQLite/Turso. \`Value::from(s)\` where \`s: &str\` produces \`Value::String(s)\` — the raw JSON wrapped as a string literal — rather than parsing it. The subsequent \`serde_json::from_value::<GroupDetail>\` therefore always failed with:

\`\`\`
SerdeJson(Error(\"invalid type: string \\\"{...}\\\", expected struct GroupDetail\"))
\`\`\`

In production, this generated thousands of error log lines per session (we observed 840+ in a 2,000-line snapshot) and prevented recovery of persisted consumer-group state across broker restarts. The native-JSON Postgres backend was not affected (it uses \`try_get::<_, serde_json::Value>(1)\`).

## Fix

Replace the broken pattern with `serde_json::from_str::<GroupDetail>(s)` so the text is actually parsed. This was already done correctly in `lite.rs::update_group`'s outdated-row branch (line ~4082), so the fix matches that style.

## Test plan

- New regression test `tansu-storage/tests/describe_groups_round_trip.rs`:
  - `update_group` writes a default `GroupDetail`, then `describe_groups` reads it back over the Storage trait.
  - Pre-fix: panics with the exact `SerdeJson(invalid type: string ...)` from production.
  - Post-fix: passes. libsql variant runs by default; turso variant is wired up behind `#[ignore]` to match how the existing turso integration tests in tansu-broker are gated.
- Existing `tansu-broker` `lite::*` produce_fetch tests still pass.