### PR TITLE
fix(auth): support SASL re-authentication on existing connections (KIP-368)

### DIFF
--- a/tansu-auth/src/handshake.rs
+++ b/tansu-auth/src/handshake.rs
@@ -43,9 +43,20 @@ where
             .lock()
             .map_err(Into::into)
             .and_then(|mut guard| {
-                if let Some(Stage::Server(server)) = guard.take()
-                    && let Ok(mechanism) = Mechname::parse(req.mechanism.as_bytes())
-                {
+                // Re-authentication (KIP-368): a Java kafka-clients
+                // connection periodically issues another SaslHandshake
+                // on the same TCP socket. The previous handshake left
+                // the Stage in `Session`/`Finished`, so a stale
+                // `take()` would fall into the else branch and reject
+                // a perfectly valid mechanism with
+                // `UnsupportedSaslMechanism`. Always start with a
+                // fresh `SASLServer` built from the stored config.
+                _ = guard.take();
+                let Stage::Server(server) = authentication.fresh_server() else {
+                    unreachable!("fresh_server returns Stage::Server")
+                };
+
+                if let Ok(mechanism) = Mechname::parse(req.mechanism.as_bytes()) {
                     debug!(available = ?server.get_available().into_iter().map(|mechanism|mechanism.mechanism.as_str()).collect::<Vec<_>>());
 
                     server

--- a/tansu-auth/src/handshake.rs
+++ b/tansu-auth/src/handshake.rs
@@ -51,12 +51,12 @@ where
                 // a perfectly valid mechanism with
                 // `UnsupportedSaslMechanism`. Always start with a
                 // fresh `SASLServer` built from the stored config.
-                _ = guard.take();
-                let Stage::Server(server) = authentication.fresh_server() else {
-                    unreachable!("fresh_server returns Stage::Server")
-                };
+                if guard.as_ref().is_none_or(|guard|!matches!(guard, Stage::Server(_))) {
+                    debug!(?guard);
+                    _ = guard.replace(authentication.fresh_server());
+                }
 
-                if let Ok(mechanism) = Mechname::parse(req.mechanism.as_bytes()) {
+                if let Some(Stage::Server(server)) = guard.take() && let Ok(mechanism) = Mechname::parse(req.mechanism.as_bytes()) {
                     debug!(available = ?server.get_available().into_iter().map(|mechanism|mechanism.mechanism.as_str()).collect::<Vec<_>>());
 
                     server

--- a/tansu-auth/src/lib.rs
+++ b/tansu-auth/src/lib.rs
@@ -76,8 +76,9 @@ impl From<SessionError> for Error {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct Authentication {
+    config: Arc<SASLConfig>,
     stage: Arc<Mutex<Option<Stage>>>,
 }
 
@@ -95,10 +96,10 @@ impl Debug for Stage {
 
 impl Authentication {
     pub fn server(config: Arc<SASLConfig>) -> Self {
+        let server = SASLServer::<Justification>::new(config.clone());
         Self {
-            stage: Arc::new(Mutex::new(Some(Stage::Server(
-                SASLServer::<Justification>::new(config),
-            )))),
+            config,
+            stage: Arc::new(Mutex::new(Some(Stage::Server(server)))),
         }
     }
 
@@ -108,6 +109,16 @@ impl Authentication {
             .map(|guard| matches!(guard.as_ref(), Some(Stage::Finished(_))))
             .ok()
             .unwrap_or_default()
+    }
+
+    /// Build a fresh `Stage::Server` from the stored config. Used by
+    /// the SASL handshake handler to support re-authentication
+    /// (KIP-368): a client periodically issues a new SaslHandshake on
+    /// an existing connection, and the broker must be willing to
+    /// initiate a new SASL exchange even though the previous one
+    /// already succeeded.
+    pub fn fresh_server(&self) -> Stage {
+        Stage::Server(SASLServer::<Justification>::new(self.config.clone()))
     }
 }
 

--- a/tansu-broker/tests/auth.rs
+++ b/tansu-broker/tests/auth.rs
@@ -194,6 +194,141 @@ async fn auth_handshake_scram_256_v1() -> Result<()> {
     Ok(())
 }
 
+/// Regression: a successful SASL handshake + authenticate must not
+/// prevent a subsequent re-authentication on the same connection
+/// (KIP-368, used by Java kafka-clients, Strimzi Kafka Connect, etc).
+///
+/// Pre-fix the second `SaslHandshakeRequest` failed with
+/// `UnsupportedSaslMechanism` because `Authentication`'s Stage had
+/// transitioned `Server -> Session -> Finished` and never reset.
+#[tokio::test]
+async fn auth_handshake_scram_256_v1_reauth() -> Result<()> {
+    let _guard = init_tracing()?;
+
+    const PRINCIPAL: &str = "alice";
+    const PASSWORD: &str = "secret";
+    const CLIENT_ID: &str = "rdkafka";
+
+    let engine = Engine::default().with_credential(
+        PRINCIPAL,
+        ScramMechanism::Scram256,
+        ScramCredential {
+            salt: Bytes::from_static(&[
+                107, 53, 50, 116, 97, 121, 49, 118, 118, 116, 105, 97, 53, 101, 54, 108, 99, 51,
+                55, 103, 110, 51, 102, 51, 104,
+            ]),
+            iterations: 8192,
+            stored_key: Bytes::from_static(&[
+                150, 254, 7, 121, 81, 205, 192, 207, 60, 206, 251, 24, 31, 131, 31, 15, 96, 75, 20,
+                228, 251, 132, 22, 235, 160, 72, 200, 130, 127, 49, 29, 150,
+            ]),
+            server_key: Bytes::from_static(&[
+                186, 175, 253, 227, 176, 106, 88, 53, 186, 173, 104, 88, 94, 40, 115, 166, 44, 183,
+                199, 177, 137, 41, 225, 132, 56, 32, 70, 255, 223, 209, 22, 146,
+            ]),
+        },
+    );
+
+    let broker = tansu_auth::configuration(engine.clone())
+        .map_err(Into::into)
+        .map(Some)
+        .and_then(|sasl_config| broker(engine, sasl_config))?;
+
+    const API_VERSION: i16 = 1;
+    let ctx = Context::default();
+    let mut correlation_id = 0;
+
+    // Run a full handshake + authenticate twice on the same broker
+    // (i.e. same `Authentication` shared via the BytesFrameLayer).
+    for round in 0..2 {
+        let response = broker
+            .serve(
+                ctx.clone(),
+                Frame::request(
+                    Header::Request {
+                        api_key: SaslHandshakeRequest::KEY,
+                        api_version: API_VERSION,
+                        correlation_id,
+                        client_id: Some(CLIENT_ID.into()),
+                    },
+                    Body::SaslHandshakeRequest(
+                        SaslHandshakeRequest::default().mechanism("SCRAM-SHA-256".into()),
+                    ),
+                )?,
+            )
+            .await?;
+
+        let response =
+            Frame::response_from_bytes(response, SaslHandshakeResponse::KEY, API_VERSION)
+                .and_then(|response| SaslHandshakeResponse::try_from(response.body))?;
+        debug!(round, ?response);
+        assert_eq!(
+            ErrorCode::None,
+            ErrorCode::try_from(response.error_code)?,
+            "SaslHandshake (round {round}) must succeed; pre-fix the second one returns \
+             UnsupportedSaslMechanism because Stage was already Finished",
+        );
+
+        let offered = response
+            .mechanisms
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|mechanism| Mechname::parse(mechanism.as_bytes()).ok())
+            .collect::<Vec<_>>();
+
+        let sasl = SASLClient::new(
+            SASLConfig::with_credentials(None, PRINCIPAL.into(), PASSWORD.into())
+                .expect("sasl credential config"),
+        );
+
+        let mut session = sasl.start_suggested(&offered).unwrap();
+        assert!(session.are_we_first());
+        let mut input = None;
+
+        loop {
+            correlation_id += 1;
+            let mut output = BytesMut::new().writer();
+
+            match session.step(input.as_deref(), &mut output).unwrap() {
+                State::Running => {
+                    let response = broker
+                        .serve(
+                            ctx.clone(),
+                            Frame::request(
+                                Header::Request {
+                                    api_key: SaslAuthenticateRequest::KEY,
+                                    api_version: API_VERSION,
+                                    correlation_id,
+                                    client_id: Some(CLIENT_ID.into()),
+                                },
+                                Body::SaslAuthenticateRequest(
+                                    SaslAuthenticateRequest::default()
+                                        .auth_bytes(Bytes::from(output.into_inner())),
+                                ),
+                            )?,
+                        )
+                        .await?;
+
+                    let response = Frame::response_from_bytes(
+                        response,
+                        SaslAuthenticateResponse::KEY,
+                        API_VERSION,
+                    )
+                    .and_then(|response| SaslAuthenticateResponse::try_from(response.body))?;
+                    debug!(round, ?response);
+                    assert_eq!(ErrorCode::None, ErrorCode::try_from(response.error_code)?);
+                    input = Some(response.auth_bytes);
+                }
+                State::Finished(_) => break,
+            }
+        }
+        correlation_id += 1;
+    }
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn auth_handshake_scram_512_v1() -> Result<()> {
     let _guard = init_tracing()?;

--- a/tansu-service/src/frame.rs
+++ b/tansu-service/src/frame.rs
@@ -234,7 +234,7 @@ impl<S> Layer<S> for BytesFrameLayer {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 struct AuthenticationFrame {
     authentication: Authentication,
     v0: Arc<Mutex<Option<bool>>>,


### PR DESCRIPTION
## Summary

`SaslHandshakeService` only proceeded when `Authentication`'s `Stage` was `Server`. After a successful initial handshake the Stage transitions \`Server -> Session -> Finished\` and never resets, so any subsequent \`SaslHandshakeRequest\` on the same TCP connection fell into the else branch and was rejected with `UnsupportedSaslMechanism` — a misleading error since the mechanism was supported, the state machine just refused to start a second exchange.

Java `kafka-clients` periodically issues `SaslHandshake` / `SaslAuthenticate` on existing connections per [KIP-368](https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate). Strimzi Kafka Connect, the Confluent Avro converter, and any other long-lived Java producer/consumer therefore failed re-authentication against tansu with:

```
Failed re-authentication with broker (channelId=N) (Client SASL
mechanism 'SCRAM-SHA-256' not enabled in the server, enabled
mechanisms are [SCRAM-SHA-256])
```

The franz-go-based clients in `redpanda-connect` ran into the same wall on their re-auth path. `rpk` happens to work because its short-lived CLI invocations don't reach the re-auth interval.

We hit this trying to bring up Strimzi Kafka Connect against a tansu broker for an S3 sink workload — the connect worker reauths every minute and dies on the first attempt.

## Fix

Keep the `Arc<SASLConfig>` alongside `Authentication` and reissue a fresh `SASLServer` at the start of every handshake, discarding any prior `Stage`. The first-handshake path is unchanged; the second-and-subsequent handshakes now succeed.

\`AuthenticationFrame\` in \`tansu-service\` had a \`#[derive(Default)]\` it never relied on; that derive is dropped to accommodate the new required \`config\` field on \`Authentication\`.

## Test plan

- New regression test \`auth_handshake_scram_256_v1_reauth\` in \`tansu-broker/tests/auth.rs\`:
  - Runs the full SCRAM-SHA-256 handshake + multi-step authenticate exchange.
  - Then issues a second \`SaslHandshakeRequest\` on the same broker service (same \`Authentication\`).
  - Asserts the second handshake's \`error_code\` is \`None\`.
  - Pre-fix this fails at the assertion with \`right: UnsupportedSaslMechanism\`.
  - Post-fix it passes.
- Existing \`auth_handshake_scram_256_v1\`, \`auth_handshake_scram_512_v1\`, \`auth_handshake_scram_512_bad_password_v1\`, \`not_authenticated\`, and \`auth_handshake_scram_256_v0\` tests continue to pass.

Validated end-to-end against a live broker (libsql backend, SCRAM-SHA-256, Strimzi Kafka Connect 0.51 with kafka-clients 4.x): pre-fix every long-lived Java consumer dies in CrashLoopBackOff with the re-auth error after the first re-auth interval; post-fix consumers stay healthy across multiple re-auth cycles.