### PR TITLE
fix(dynostore): seek fetch with start-after instead of listing whole prefix

### DIFF
--- a/tansu-storage/src/dynostore.rs
+++ b/tansu-storage/src/dynostore.rs
@@ -15,7 +15,7 @@
 //! Dynamic Object Storage engine (S3, memory, ...)
 
 use std::{
-    collections::{BTreeMap, BTreeSet, btree_map::Entry},
+    collections::{BTreeMap, btree_map::Entry},
     fmt::{Debug, Display},
     str::FromStr,
     sync::{Arc, Mutex},
@@ -1016,16 +1016,37 @@ impl Storage for DynoStore {
 
         debug!(high_watermark);
 
-        let mut offsets = BTreeSet::new();
+        let mut batches = vec![];
 
         if offset < high_watermark {
-            let location = Path::from(format!(
+            let prefix = Path::from(format!(
                 "clusters/{}/topics/{}/partitions/{:0>10}/records/",
                 self.cluster, topition.topic, topition.partition
             ));
 
-            let mut list_stream = self.object_store.list(Some(&location));
+            // Seek directly to the requested offset using `start-after` instead of
+            // enumerating the whole partition prefix on every fetch. Batch filenames are
+            // zero-padded to 20 digits, so lexicographic order == numeric order. The start
+            // key is the 20-digit offset *without* the `.batch` suffix: it is a strict prefix
+            // of `{offset:0>20}.batch`, so listing returns exactly `base_offset >= offset`
+            // (matching the previous `split_off(&offset)` semantics) while also handling
+            // `offset == 0` without underflow.
+            let start_after = Path::from(format!(
+                "clusters/{}/topics/{}/partitions/{:0>10}/records/{:0>20}",
+                self.cluster, topition.topic, topition.partition, offset,
+            ));
 
+            let mut list_stream = self
+                .object_store
+                .list_with_offset(Some(&prefix), &start_after);
+
+            let mut bytes = max_bytes as u64;
+
+            // The object_store trait does not guarantee ordering, but every dynostore backend
+            // yields ascending keys (S3 ListObjectsV2 sorts by key, the memory store iterates a
+            // BTreeMap). We rely on that to stop as soon as enough batches to satisfy `max_bytes`
+            // are collected, keeping fetch cost proportional to the bytes returned rather than to
+            // the partition's history.
             while let Some(meta) = list_stream
                 .next()
                 .await
@@ -1035,53 +1056,38 @@ impl Storage for DynoStore {
                 .map_err(|_| Error::Api(ErrorCode::UnknownServerError))?
                 && !has_deadline_expired()
             {
-                let Some(offset) = meta.location.parts().next_back() else {
+                let Some(file_name) = meta.location.parts().next_back() else {
                     continue;
                 };
 
-                let offset = i64::from_str(&offset.as_ref()[0..20])?;
-                debug!(offset);
+                let base_offset = i64::from_str(&file_name.as_ref()[0..20])?;
+                debug!(base_offset);
 
-                if offset < high_watermark {
-                    _ = offsets.insert(offset);
+                if base_offset >= high_watermark {
+                    break;
                 }
-            }
-        }
 
-        let mut batches = vec![];
+                let size = meta.size;
 
-        let mut bytes = max_bytes as u64;
+                let mut batch = self
+                    .object_store
+                    .get(&meta.location)
+                    .await
+                    .inspect_err(|error| error!(?error, ?topition, ?offset, ?min_bytes, ?max_bytes))
+                    .map_err(|_| Error::Api(ErrorCode::UnknownServerError))?
+                    .bytes()
+                    .await
+                    .inspect_err(|error| error!(?error, location = %meta.location))
+                    .map_err(|_| Error::Api(ErrorCode::UnknownServerError))
+                    .and_then(|encoded| self.decode(encoded))?;
+                batch.base_offset = base_offset;
+                batches.push(batch);
 
-        for offset in offsets.split_off(&offset) {
-            debug!(?offset);
-
-            let location = Path::from(format!(
-                "clusters/{}/topics/{}/partitions/{:0>10}/records/{:0>20}.batch",
-                self.cluster, topition.topic, topition.partition, offset,
-            ));
-
-            let get_result = self
-                .object_store
-                .get(&location)
-                .await
-                .inspect_err(|error| error!(?error, ?topition, ?offset, ?min_bytes, ?max_bytes))
-                .map_err(|_| Error::Api(ErrorCode::UnknownServerError))?;
-
-            let size = get_result.meta.size;
-
-            let mut batch = get_result
-                .bytes()
-                .await
-                .inspect_err(|error| error!(?error, %location))
-                .map_err(|_| Error::Api(ErrorCode::UnknownServerError))
-                .and_then(|encoded| self.decode(encoded))?;
-            batch.base_offset = offset;
-            batches.push(batch);
-
-            if size > bytes || has_deadline_expired() {
-                break;
-            } else {
-                bytes = bytes.saturating_sub(size);
+                if size > bytes || has_deadline_expired() {
+                    break;
+                } else {
+                    bytes = bytes.saturating_sub(size);
+                }
             }
         }
 

--- a/tansu-storage/tests/fetch.rs
+++ b/tansu-storage/tests/fetch.rs
@@ -106,3 +106,166 @@ mod doctest_template {
         Ok(())
     }
 }
+
+/// Exercises the `start-after` based fetch on the `dynostore` (`memory://`) engine: fetch must
+/// return the contiguous run of batches at or after the requested offset, bounded by `max_bytes`,
+/// without depending on the partition's total history.
+mod start_after {
+    use std::{sync::Arc, time::Duration};
+
+    use bytes::Bytes;
+    use tansu_sans_io::{
+        IsolationLevel,
+        record::{Record, deflated, inflated},
+    };
+    use tansu_storage::{Storage, StorageContainer, Topition};
+    use url::Url;
+
+    use crate::common::{Error, init_tracing};
+
+    const CLUSTER_ID: &str = "tansu";
+    const NODE_ID: i32 = 111;
+    const MAX_WAIT: Duration = Duration::from_secs(5);
+
+    async fn in_memory_storage() -> Result<Arc<Box<dyn Storage>>, Error> {
+        StorageContainer::builder()
+            .cluster_id(CLUSTER_ID)
+            .node_id(NODE_ID)
+            .advertised_listener(Url::parse("tcp://localhost:9092")?)
+            .storage(Url::parse("memory://tansu/")?)
+            .build()
+            .await
+            .map_err(Into::into)
+    }
+
+    fn single_record_batch(value: &'static [u8]) -> Result<deflated::Batch, Error> {
+        inflated::Batch::builder()
+            .record(Record::builder().value(Bytes::from_static(value).into()))
+            .build()
+            .and_then(deflated::Batch::try_from)
+            .map_err(Into::into)
+    }
+
+    /// Produce `count` single-record batches; each occupies one offset, so base offsets are
+    /// `0..count` and the high watermark ends at `count`.
+    async fn produce_batches(
+        storage: &Arc<Box<dyn Storage>>,
+        topition: &Topition,
+        count: i64,
+    ) -> Result<(), Error> {
+        for offset in 0..count {
+            let assigned = storage
+                .produce(None, topition, single_record_batch(b"lorem ipsum")?)
+                .await?;
+            assert_eq!(offset, assigned);
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fetch_from_middle_returns_contiguous_tail() -> Result<(), Error> {
+        let _guard = init_tracing()?;
+
+        let storage = in_memory_storage().await?;
+        let topition = Topition::new("abcba", 0);
+
+        produce_batches(&storage, &topition, 10).await?;
+
+        let batches = storage
+            .fetch(
+                &topition,
+                4,
+                0,
+                1024 * 1024,
+                IsolationLevel::ReadUncommitted,
+                MAX_WAIT,
+            )
+            .await?;
+
+        let base_offsets = batches.iter().map(|b| b.base_offset).collect::<Vec<_>>();
+        assert_eq!(vec![4, 5, 6, 7, 8, 9], base_offsets);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fetch_from_start_returns_all() -> Result<(), Error> {
+        let _guard = init_tracing()?;
+
+        let storage = in_memory_storage().await?;
+        let topition = Topition::new("abcba", 0);
+
+        produce_batches(&storage, &topition, 10).await?;
+
+        let batches = storage
+            .fetch(
+                &topition,
+                0,
+                0,
+                1024 * 1024,
+                IsolationLevel::ReadUncommitted,
+                MAX_WAIT,
+            )
+            .await?;
+
+        let base_offsets = batches.iter().map(|b| b.base_offset).collect::<Vec<_>>();
+        assert_eq!((0..10).collect::<Vec<_>>(), base_offsets);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fetch_is_bounded_by_max_bytes() -> Result<(), Error> {
+        let _guard = init_tracing()?;
+
+        let storage = in_memory_storage().await?;
+        let topition = Topition::new("abcba", 0);
+
+        produce_batches(&storage, &topition, 10).await?;
+
+        // A single byte budget always yields at least one batch (Kafka semantics) but never the
+        // whole partition.
+        let batches = storage
+            .fetch(
+                &topition,
+                0,
+                0,
+                1,
+                IsolationLevel::ReadUncommitted,
+                MAX_WAIT,
+            )
+            .await?;
+
+        assert_eq!(1, batches.len());
+        assert_eq!(0, batches[0].base_offset);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fetch_at_or_beyond_high_watermark_is_empty() -> Result<(), Error> {
+        let _guard = init_tracing()?;
+
+        let storage = in_memory_storage().await?;
+        let topition = Topition::new("abcba", 0);
+
+        produce_batches(&storage, &topition, 10).await?;
+
+        for offset in [10, 11, 100] {
+            let batches = storage
+                .fetch(
+                    &topition,
+                    offset,
+                    0,
+                    1024 * 1024,
+                    IsolationLevel::ReadUncommitted,
+                    MAX_WAIT,
+                )
+                .await?;
+            assert!(batches.is_empty(), "offset {offset} should be empty");
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Problem

On the S3 / `dynostore` engine, `Storage::fetch` listed the **entire** partition `records/` prefix and built a `BTreeSet` of **all** batch base-offsets on **every** call, regardless of the requested offset. Each fetch therefore cost O(total batches) in S3 LIST calls, CPU and transient memory instead of scaling with the bytes actually returned.

A consumer reading a partition from the start and advancing fetch-by-fetch re-listed the whole (and growing) prefix each time → roughly quadratic over a full read.

Closes #684.

## Fix

Replace the full-prefix `list()` + `BTreeSet` + `split_off(&offset)` with a single `list_with_offset(prefix, start_after)` stream:

- Batch filenames are zero-padded to 20 digits, so lexicographic order == numeric order; on S3 `start-after` is pushed down to `ListObjectsV2`.
- The start key is the 20-digit offset **without** the `.batch` suffix — a strict prefix of `{offset:0>20}.batch` — so listing returns exactly `base_offset >= offset`, matching the previous `split_off(&offset)` semantics, and handles `offset == 0` without underflow.
- Iterate in ascending key order, reading batches until `max_bytes` is satisfied (always returning at least one batch) or `high_watermark` is reached.
- Size is read from the listed `ObjectMeta`, dropping the redundant `get_result.meta.size` round-trip.

Fetch cost and transient memory now scale with the bytes returned rather than the partition's history.

### Ordering note

The `object_store` trait does not guarantee listing order, but every dynostore backend yields ascending keys (S3 `ListObjectsV2` sorts by key; the memory store iterates a `BTreeMap`), which the early-break relies on. This is documented in a comment. On backends without native `start-after` push-down (memory, local FS) `list_with_offset` filters client-side, so the LIST-cost win is primarily on S3 — but the early-break correctness benefits all backends.

## Tests

Added 4 tests on the `memory://` backend in `tansu-storage/tests/fetch.rs`:

- `fetch_from_middle_returns_contiguous_tail` — offset 4 → `[4..9]`
- `fetch_from_start_returns_all` — offset 0 → `[0..9]`
- `fetch_is_bounded_by_max_bytes` — `max_bytes = 1` → exactly one batch
- `fetch_at_or_beyond_high_watermark_is_empty`

All new tests plus the existing `fetch`/`produce`/`list_offsets` suites pass. `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)