### PR TITLE
Implement delete and compact cleanup policies for dynostore

### DIFF
--- a/tansu-broker/tests/policy_compact_delete.rs
+++ b/tansu-broker/tests/policy_compact_delete.rs
@@ -2963,7 +2963,6 @@ mod in_memory {
         .await
     }
 
-    #[ignore]
     #[tokio::test]
     async fn compact_only() -> Result<()> {
         let _guard = init_tracing()?;
@@ -2977,6 +2976,12 @@ mod in_memory {
         super::compact_only(sc).await
     }
 
+    // NOTE: dynostore stores one batch per produce request and `fetch` returns
+    // those batches verbatim, whereas the shared `delete_only` /
+    // `delete_no_retention_ms_only` assertions assume the SQL backends'
+    // record-level re-batching (all records coalesced into a single batch).
+    // The retention/delete cleanup policy itself is covered for dynostore by
+    // `tansu-storage/tests/policy_delete.rs`.
     #[ignore]
     #[tokio::test]
     async fn delete_only() -> Result<()> {

--- a/tansu-storage/src/dynostore.rs
+++ b/tansu-storage/src/dynostore.rs
@@ -50,7 +50,7 @@ use tansu_sans_io::{
     create_topics_request::{CreatableTopic, CreatableTopicConfig},
     delete_groups_response::DeletableGroupResult,
     delete_records_request::DeleteRecordsTopic,
-    delete_records_response::DeleteRecordsTopicResult,
+    delete_records_response::{DeleteRecordsPartitionResult, DeleteRecordsTopicResult},
     describe_cluster_response::DescribeClusterBroker,
     describe_configs_response::{DescribeConfigsResourceResult, DescribeConfigsResult},
     describe_topic_partitions_response::{
@@ -326,7 +326,6 @@ struct TopicMetadata {
 struct Watermark {
     low: Option<i64>,
     high: Option<i64>,
-    timestamps: Option<BTreeMap<i64, i64>>,
 }
 
 impl OptiCon<Watermark> {
@@ -398,6 +397,325 @@ impl DynoStore {
                 }
             })
             .await
+    }
+
+    fn records_prefix(&self, topition: &Topition) -> Path {
+        Path::from(format!(
+            "clusters/{}/topics/{}/partitions/{:0>10}/records/",
+            self.cluster, topition.topic, topition.partition,
+        ))
+    }
+
+    fn batch_location(&self, topition: &Topition, offset: i64) -> Path {
+        Path::from(format!(
+            "clusters/{}/topics/{}/partitions/{:0>10}/records/{:0>20}.batch",
+            self.cluster, topition.topic, topition.partition, offset,
+        ))
+    }
+
+    fn watermark(&self, topition: &Topition) -> Result<OptiCon<Watermark>> {
+        self.watermarks
+            .lock()
+            .map(|mut locked| {
+                locked
+                    .entry(topition.to_owned())
+                    .or_insert_with(|| OptiCon::<Watermark>::new(self.cluster.as_str(), topition))
+                    .to_owned()
+            })
+            .map_err(Into::into)
+    }
+
+    /// Enforce the `delete` cleanup policy: for every topic configured with
+    /// `cleanup.policy` containing `delete`, drop the batches whose records are
+    /// older than `retention.ms` (defaulting to 7 days, matching the SQL
+    /// backends). Returns the number of batches removed.
+    #[instrument(skip(self), ret)]
+    async fn policy_delete(&self, now: SystemTime) -> Result<u64> {
+        const DEFAULT_RETENTION: Duration = Duration::from_hours(7 * 24);
+
+        let now_ms = i64::try_from(
+            now.duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis(),
+        )
+        .unwrap_or(i64::MAX);
+
+        let topics = self
+            .meta
+            .with(&self.object_store, |meta| {
+                Ok(meta
+                    .topics
+                    .values()
+                    .filter_map(|metadata| {
+                        let configs = metadata.topic.configs.as_deref().unwrap_or_default();
+
+                        let delete = configs.iter().any(|config| {
+                            config.name == "cleanup.policy"
+                                && config
+                                    .value
+                                    .as_deref()
+                                    .is_some_and(|value| value.contains("delete"))
+                        });
+
+                        if !delete {
+                            return None;
+                        }
+
+                        let retention_ms = configs
+                            .iter()
+                            .find(|config| config.name == "retention.ms")
+                            .and_then(|config| config.value.as_deref())
+                            .and_then(|value| i64::from_str(value).ok())
+                            .unwrap_or(DEFAULT_RETENTION.as_millis() as i64);
+
+                        Some((
+                            metadata.topic.name.clone(),
+                            metadata.topic.num_partitions,
+                            retention_ms,
+                        ))
+                    })
+                    .collect::<Vec<_>>())
+            })
+            .await?;
+
+        let mut deleted = 0;
+
+        for (topic, num_partitions, retention_ms) in topics {
+            let threshold_ms = now_ms.saturating_sub(retention_ms);
+
+            for partition in 0..num_partitions {
+                let topition = Topition::new(topic.clone(), partition);
+
+                deleted += self
+                    .expire_partition(&topition, threshold_ms)
+                    .await
+                    .inspect_err(|err| error!(?err, ?topition))?;
+            }
+        }
+
+        Ok(deleted)
+    }
+
+    /// List the batch files of `topition` as a map of base offset to its object
+    /// metadata (sorted ascending by offset).
+    async fn list_batch_offsets(&self, topition: &Topition) -> Result<BTreeMap<i64, ObjectMeta>> {
+        let prefix = self.records_prefix(topition);
+
+        let mut offsets = BTreeMap::new();
+        let mut list_stream = self.object_store.list(Some(&prefix));
+
+        while let Some(meta) = list_stream
+            .next()
+            .await
+            .transpose()
+            .inspect_err(|err| error!(?err, ?topition))?
+        {
+            let Some(name) = meta.location.parts().next_back() else {
+                continue;
+            };
+
+            let Ok(offset) = i64::from_str(&name.as_ref()[0..20]) else {
+                continue;
+            };
+
+            _ = offsets.insert(offset, meta);
+        }
+
+        Ok(offsets)
+    }
+
+    /// Set the log start offset (`watermark.low`) to `low`.
+    async fn advance_low_watermark(&self, topition: &Topition, low: Option<i64>) -> Result<()> {
+        self.watermark(topition)?
+            .with_mut(&self.object_store, |watermark| {
+                watermark.low = low;
+                Ok(())
+            })
+            .await
+    }
+
+    /// Delete the given batch object locations concurrently.
+    async fn delete_batches(&self, locations: Vec<Path>) -> Result<()> {
+        if locations.is_empty() {
+            return Ok(());
+        }
+
+        let locations = futures::stream::iter(locations.into_iter().map(Ok)).boxed();
+
+        self.object_store
+            .delete_stream(locations)
+            .try_collect::<Vec<Path>>()
+            .await
+            .map(|_| ())
+            .map_err(Into::into)
+    }
+
+    /// Delete every batch of `topition` written before `now - retention_ms`, then
+    /// advance the log start offset (`watermark.low`) to the oldest surviving
+    /// batch. Age is taken from the object's `last_modified` (the append time),
+    /// streamed from the object store so no per-batch GET is required.
+    async fn expire_partition(&self, topition: &Topition, threshold_ms: i64) -> Result<u64> {
+        let mut expired = vec![];
+        let mut surviving_low: Option<i64> = None;
+
+        for (offset, meta) in self.list_batch_offsets(topition).await? {
+            if meta.last_modified.timestamp_millis() < threshold_ms {
+                expired.push(meta.location);
+            } else if surviving_low.is_none_or(|low| offset < low) {
+                surviving_low = Some(offset);
+            }
+        }
+
+        if expired.is_empty() {
+            return Ok(0);
+        }
+
+        let deleted = expired.len() as u64;
+
+        self.delete_batches(expired).await?;
+        self.advance_low_watermark(topition, surviving_low).await?;
+
+        Ok(deleted)
+    }
+
+    /// Delete every batch of `topition` whose base offset is below `before` and
+    /// set the log start offset to `before`. `before` of `-1` means the log end
+    /// offset (delete everything). Returns the new log start offset.
+    async fn delete_records_before(&self, topition: &Topition, before: i64) -> Result<i64> {
+        let high = self
+            .watermark(topition)?
+            .with(&self.object_store, |watermark| {
+                Ok(watermark.high.unwrap_or(0))
+            })
+            .await?;
+
+        let before = if before < 0 { high } else { before.min(high) };
+
+        let removed = self
+            .list_batch_offsets(topition)
+            .await?
+            .into_iter()
+            .filter(|(offset, _)| *offset < before)
+            .map(|(_, meta)| meta.location)
+            .collect::<Vec<_>>();
+
+        self.delete_batches(removed).await?;
+        self.advance_low_watermark(topition, Some(before)).await?;
+
+        Ok(before)
+    }
+
+    /// Enforce the `compact` cleanup policy: for every topic configured with
+    /// `cleanup.policy` containing `compact`, keep only the latest record per key
+    /// (by offset), dropping the earlier versions. Surviving offsets are
+    /// preserved. Returns the number of records removed.
+    #[instrument(skip(self), ret)]
+    async fn policy_compact(&self) -> Result<u64> {
+        let topics = self
+            .meta
+            .with(&self.object_store, |meta| {
+                Ok(meta
+                    .topics
+                    .values()
+                    .filter_map(|metadata| {
+                        let configs = metadata.topic.configs.as_deref().unwrap_or_default();
+
+                        let compact = configs.iter().any(|config| {
+                            config.name == "cleanup.policy"
+                                && config
+                                    .value
+                                    .as_deref()
+                                    .is_some_and(|value| value.contains("compact"))
+                        });
+
+                        compact
+                            .then(|| (metadata.topic.name.clone(), metadata.topic.num_partitions))
+                    })
+                    .collect::<Vec<_>>())
+            })
+            .await?;
+
+        let mut compacted = 0;
+
+        for (topic, num_partitions) in topics {
+            for partition in 0..num_partitions {
+                let topition = Topition::new(topic.clone(), partition);
+
+                compacted += self
+                    .compact_partition(&topition)
+                    .await
+                    .inspect_err(|err| error!(?err, ?topition))?;
+            }
+        }
+
+        Ok(compacted)
+    }
+
+    /// Compact a single partition: walking the batches newest first, drop every
+    /// record whose key reappears in a more recent batch (and earlier duplicates
+    /// within a batch). Emptied batch files are removed, partially compacted ones
+    /// are rewritten in place (preserving base offset and record offsets).
+    async fn compact_partition(&self, topition: &Topition) -> Result<u64> {
+        let offsets = self.list_batch_offsets(topition).await?;
+
+        if offsets.is_empty() {
+            return Ok(0);
+        }
+
+        let mut seen: BTreeSet<Bytes> = BTreeSet::new();
+        let mut removed = vec![];
+        let mut surviving_low: Option<i64> = None;
+        let mut compacted = 0;
+
+        // newest to oldest: a key kept in a newer batch supersedes older ones
+        for offset in offsets.into_keys().rev() {
+            let location = self.batch_location(topition, offset);
+
+            let deflated = match self.object_store.get(&location).await {
+                Ok(get_result) => self.decode(get_result.bytes().await?)?,
+                Err(object_store::Error::NotFound { .. }) => continue,
+                Err(err) => return Err(err.into()),
+            };
+
+            let inflated::Compaction { batch, records } =
+                inflated::Batch::try_from(&deflated)?.compact(&seen)?;
+
+            compacted += records;
+            seen.extend(batch.keys());
+
+            if batch.records.is_empty() {
+                removed.push(location);
+            } else {
+                if records > 0 {
+                    let payload = self.encode(deflated::Batch::try_from(batch)?)?;
+
+                    _ = self
+                        .object_store
+                        .put_opts(
+                            &location,
+                            payload,
+                            PutOptions {
+                                mode: PutMode::Overwrite,
+                                attributes: Attributes::new(),
+                                ..Default::default()
+                            },
+                        )
+                        .await
+                        .inspect_err(|err| error!(?err, ?topition, offset))?;
+                }
+
+                if surviving_low.is_none_or(|low| offset < low) {
+                    surviving_low = Some(offset);
+                }
+            }
+        }
+
+        if !removed.is_empty() {
+            self.delete_batches(removed).await?;
+            self.advance_low_watermark(topition, surviving_low).await?;
+        }
+
+        Ok(compacted as u64)
     }
 
     fn encode(&self, deflated: deflated::Batch) -> Result<PutPayload> {
@@ -615,9 +933,50 @@ impl Storage for DynoStore {
 
     async fn delete_records(
         &self,
-        _topics: &[DeleteRecordsTopic],
+        topics: &[DeleteRecordsTopic],
     ) -> Result<Vec<DeleteRecordsTopicResult>> {
-        todo!()
+        debug!(cluster = self.cluster, ?topics);
+
+        let mut responses = vec![];
+
+        for topic in topics {
+            let mut partition_responses = vec![];
+
+            if let Some(ref partitions) = topic.partitions {
+                for partition in partitions {
+                    let topition = Topition::new(topic.name.clone(), partition.partition_index);
+
+                    let partition_result = match self
+                        .delete_records_before(&topition, partition.offset)
+                        .await
+                    {
+                        Ok(low_watermark) => DeleteRecordsPartitionResult::default()
+                            .partition_index(partition.partition_index)
+                            .low_watermark(low_watermark)
+                            .error_code(ErrorCode::None.into()),
+
+                        Err(err) => {
+                            error!(?err, ?topition);
+
+                            DeleteRecordsPartitionResult::default()
+                                .partition_index(partition.partition_index)
+                                .low_watermark(0)
+                                .error_code(ErrorCode::UnknownServerError.into())
+                        }
+                    };
+
+                    partition_responses.push(partition_result);
+                }
+            }
+
+            responses.push(
+                DeleteRecordsTopicResult::default()
+                    .name(topic.name.clone())
+                    .partitions(Some(partition_responses)),
+            );
+        }
+
+        Ok(responses)
     }
 
     async fn delete_topic(&self, topic: &TopicId) -> Result<ErrorCode> {
@@ -759,8 +1118,6 @@ impl Storage for DynoStore {
                         |high| Some(high + deflated.last_offset_delta as i64 + 1i64),
                     );
 
-                    watermark.timestamps = None;
-
                     debug!(?watermark);
 
                     Ok(offset)
@@ -885,8 +1242,6 @@ impl Storage for DynoStore {
                         || Some(deflated.last_offset_delta as i64 + 1i64),
                         |high| Some(high + deflated.last_offset_delta as i64 + 1i64),
                     );
-
-                    watermark.timestamps = None;
 
                     debug!(?watermark);
 
@@ -2614,7 +2969,11 @@ impl Storage for DynoStore {
         Ok(ErrorCode::None)
     }
 
-    async fn maintain(&self, _now: SystemTime) -> Result<()> {
+    async fn maintain(&self, now: SystemTime) -> Result<()> {
+        let deleted = self.policy_delete(now).await?;
+        let compacted = self.policy_compact().await?;
+        debug!(deleted, compacted);
+
         if let Some(ref lake) = self.lake {
             return lake
                 .maintain()

--- a/tansu-storage/tests/delete_records.rs
+++ b/tansu-storage/tests/delete_records.rs
@@ -24,7 +24,6 @@ use url::Url;
 
 mod common;
 
-#[ignore]
 #[tokio::test]
 async fn delete_non_existent_records() -> Result<(), Error> {
     let _guard = init_tracing()?;

--- a/tansu-storage/tests/policy_compact.rs
+++ b/tansu-storage/tests/policy_compact.rs
@@ -1,0 +1,259 @@
+// Copyright ⓒ 2024-2026 Peter Morgan <peter.james.morgan@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `cleanup.policy=compact` for the dynostore (object store) backend.
+
+use std::{sync::Arc, time::Duration};
+
+use crate::common::{Error, init_tracing};
+use bytes::Bytes;
+use tansu_sans_io::{
+    IsolationLevel,
+    create_topics_request::{CreatableTopic, CreatableTopicConfig},
+    record::{Record, deflated, inflated},
+};
+use tansu_storage::{Storage, StorageContainer, Topition};
+use url::Url;
+
+mod common;
+
+type Sc = Arc<Box<dyn Storage>>;
+
+async fn memory_storage() -> Result<Sc, Error> {
+    StorageContainer::builder()
+        .cluster_id("tansu")
+        .node_id(111)
+        .advertised_listener(Url::parse("tcp://localhost:9092")?)
+        .storage(Url::parse("memory://tansu/")?)
+        .build()
+        .await
+        .map_err(Into::into)
+}
+
+async fn create_topic(
+    storage: &Sc,
+    name: &str,
+    configs: Vec<CreatableTopicConfig>,
+) -> Result<(), Error> {
+    _ = storage
+        .create_topic(
+            CreatableTopic::default()
+                .name(name.into())
+                .num_partitions(1)
+                .replication_factor(0)
+                .assignments(Some([].into()))
+                .configs(Some(configs)),
+            false,
+        )
+        .await?;
+
+    Ok(())
+}
+
+fn cleanup_compact() -> Vec<CreatableTopicConfig> {
+    vec![
+        CreatableTopicConfig::default()
+            .name("cleanup.policy".into())
+            .value(Some("compact".into())),
+    ]
+}
+
+fn keyed_batch(key: &'static [u8], value: &'static [u8]) -> Result<deflated::Batch, Error> {
+    inflated::Batch::builder()
+        .record(
+            Record::builder()
+                .key(Some(Bytes::from_static(key)))
+                .value(Some(Bytes::from_static(value))),
+        )
+        .build()
+        .and_then(deflated::Batch::try_from)
+        .map_err(Into::into)
+}
+
+/// (key, value, absolute offset) of every record currently fetchable.
+async fn fetched_records(
+    storage: &Sc,
+    topition: &Topition,
+) -> Result<Vec<(Option<Bytes>, Option<Bytes>, i64)>, Error> {
+    let batches = storage
+        .fetch(
+            topition,
+            0,
+            1,
+            64 * 1024,
+            IsolationLevel::ReadUncommitted,
+            Duration::from_millis(500),
+        )
+        .await?;
+
+    let mut records = vec![];
+
+    for deflated in &batches {
+        let inflated = inflated::Batch::try_from(deflated)?;
+
+        for record in &inflated.records {
+            records.push((
+                record.key.clone(),
+                record.value.clone(),
+                inflated.base_offset + i64::from(record.offset_delta),
+            ));
+        }
+    }
+
+    Ok(records)
+}
+
+#[tokio::test]
+async fn keeps_latest_per_key() -> Result<(), Error> {
+    let _guard = init_tracing()?;
+
+    let storage = memory_storage().await?;
+
+    create_topic(&storage, "kv", cleanup_compact()).await?;
+
+    let topition = Topition::new("kv", 0);
+
+    // three single-record batches, all the same key (offsets 0, 1, 2)
+    for value in [b"one".as_slice(), b"two".as_slice(), b"three".as_slice()] {
+        _ = storage
+            .produce(None, &topition, keyed_batch(b"alpha", value)?)
+            .await?;
+    }
+
+    assert_eq!(3, fetched_records(&storage, &topition).await?.len());
+
+    storage.maintain(std::time::SystemTime::now()).await?;
+
+    // only the latest record for the key survives, at its original offset
+    let records = fetched_records(&storage, &topition).await?;
+    assert_eq!(
+        vec![(
+            Some(Bytes::from_static(b"alpha")),
+            Some(Bytes::from_static(b"three")),
+            2,
+        )],
+        records
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn distinct_keys_are_retained() -> Result<(), Error> {
+    let _guard = init_tracing()?;
+
+    let storage = memory_storage().await?;
+
+    create_topic(&storage, "kv", cleanup_compact()).await?;
+
+    let topition = Topition::new("kv", 0);
+
+    _ = storage
+        .produce(None, &topition, keyed_batch(b"a", b"1")?)
+        .await?;
+    _ = storage
+        .produce(None, &topition, keyed_batch(b"b", b"2")?)
+        .await?;
+
+    storage.maintain(std::time::SystemTime::now()).await?;
+
+    // different keys: nothing is superseded
+    assert_eq!(2, fetched_records(&storage, &topition).await?.len());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn compacts_within_a_multi_record_batch() -> Result<(), Error> {
+    let _guard = init_tracing()?;
+
+    let storage = memory_storage().await?;
+
+    create_topic(&storage, "kv", cleanup_compact()).await?;
+
+    let topition = Topition::new("kv", 0);
+
+    // a single batch holding k1@0, k2@1, k1@2 — k1@0 is superseded by k1@2
+    let batch = inflated::Batch::builder()
+        .last_offset_delta(2)
+        .record(
+            Record::builder()
+                .offset_delta(0)
+                .key(Some(Bytes::from_static(b"k1")))
+                .value(Some(Bytes::from_static(b"v1"))),
+        )
+        .record(
+            Record::builder()
+                .offset_delta(1)
+                .key(Some(Bytes::from_static(b"k2")))
+                .value(Some(Bytes::from_static(b"v2"))),
+        )
+        .record(
+            Record::builder()
+                .offset_delta(2)
+                .key(Some(Bytes::from_static(b"k1")))
+                .value(Some(Bytes::from_static(b"v3"))),
+        )
+        .build()
+        .and_then(deflated::Batch::try_from)?;
+
+    _ = storage.produce(None, &topition, batch).await?;
+
+    assert_eq!(3, fetched_records(&storage, &topition).await?.len());
+
+    storage.maintain(std::time::SystemTime::now()).await?;
+
+    // the batch is rewritten in place: k2@1 and k1@3 survive, offsets preserved
+    let records = fetched_records(&storage, &topition).await?;
+    assert_eq!(
+        vec![
+            (
+                Some(Bytes::from_static(b"k2")),
+                Some(Bytes::from_static(b"v2")),
+                1,
+            ),
+            (
+                Some(Bytes::from_static(b"k1")),
+                Some(Bytes::from_static(b"v3")),
+                2,
+            ),
+        ],
+        records
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn without_compact_policy_nothing_is_removed() -> Result<(), Error> {
+    let _guard = init_tracing()?;
+
+    let storage = memory_storage().await?;
+
+    create_topic(&storage, "plain", vec![]).await?;
+
+    let topition = Topition::new("plain", 0);
+
+    for value in [b"one".as_slice(), b"two".as_slice(), b"three".as_slice()] {
+        _ = storage
+            .produce(None, &topition, keyed_batch(b"alpha", value)?)
+            .await?;
+    }
+
+    storage.maintain(std::time::SystemTime::now()).await?;
+
+    assert_eq!(3, fetched_records(&storage, &topition).await?.len());
+
+    Ok(())
+}

--- a/tansu-storage/tests/policy_delete.rs
+++ b/tansu-storage/tests/policy_delete.rs
@@ -1,0 +1,212 @@
+// Copyright ⓒ 2024-2026 Peter Morgan <peter.james.morgan@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `cleanup.policy=delete` (retention) for the dynostore (object store) backend.
+
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+
+use crate::common::{Error, init_tracing};
+use bytes::Bytes;
+use tansu_sans_io::{
+    IsolationLevel,
+    create_topics_request::{CreatableTopic, CreatableTopicConfig},
+    record::{Record, deflated, inflated},
+};
+use tansu_storage::{Storage, StorageContainer, Topition};
+use url::Url;
+
+mod common;
+
+type Sc = Arc<Box<dyn Storage>>;
+
+async fn memory_storage() -> Result<Sc, Error> {
+    StorageContainer::builder()
+        .cluster_id("tansu")
+        .node_id(111)
+        .advertised_listener(Url::parse("tcp://localhost:9092")?)
+        .storage(Url::parse("memory://tansu/")?)
+        .build()
+        .await
+        .map_err(Into::into)
+}
+
+fn batch(value: &'static [u8]) -> Result<deflated::Batch, Error> {
+    inflated::Batch::builder()
+        .record(Record::builder().value(Some(Bytes::from_static(value))))
+        .build()
+        .and_then(deflated::Batch::try_from)
+        .map_err(Into::into)
+}
+
+async fn create_topic(
+    storage: &Sc,
+    name: &str,
+    configs: Vec<CreatableTopicConfig>,
+) -> Result<(), Error> {
+    _ = storage
+        .create_topic(
+            CreatableTopic::default()
+                .name(name.into())
+                .num_partitions(1)
+                .replication_factor(0)
+                .assignments(Some([].into()))
+                .configs(Some(configs)),
+            false,
+        )
+        .await?;
+
+    Ok(())
+}
+
+async fn fetch_len(storage: &Sc, topition: &Topition) -> Result<usize, Error> {
+    storage
+        .fetch(
+            topition,
+            0,
+            1,
+            64 * 1024,
+            IsolationLevel::ReadUncommitted,
+            Duration::from_millis(500),
+        )
+        .await
+        .map(|batches| batches.len())
+        .map_err(Into::into)
+}
+
+async fn produce_three(storage: &Sc, topition: &Topition) -> Result<(), Error> {
+    for value in [b"one".as_slice(), b"two".as_slice(), b"three".as_slice()] {
+        _ = storage.produce(None, topition, batch(value)?).await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn retention_ms_expires_old_records() -> Result<(), Error> {
+    let _guard = init_tracing()?;
+
+    let storage = memory_storage().await?;
+
+    let retention = Duration::from_mins(30);
+
+    create_topic(
+        &storage,
+        "retained",
+        vec![
+            CreatableTopicConfig::default()
+                .name("cleanup.policy".into())
+                .value(Some("delete".into())),
+            CreatableTopicConfig::default()
+                .name("retention.ms".into())
+                .value(Some(retention.as_millis().to_string())),
+        ],
+    )
+    .await?;
+
+    let topition = Topition::new("retained", 0);
+
+    produce_three(&storage, &topition).await?;
+
+    // the three batches are present
+    assert_eq!(3, fetch_len(&storage, &topition).await?);
+
+    // a maintenance pass now keeps everything: nothing is older than 30m
+    storage.maintain(SystemTime::now()).await?;
+    assert_eq!(3, fetch_len(&storage, &topition).await?);
+
+    // a maintenance pass an hour into the future ages every batch out
+    let later = SystemTime::now()
+        .checked_add(retention + Duration::from_mins(30))
+        .expect("an hour ahead");
+    storage.maintain(later).await?;
+
+    assert_eq!(0, fetch_len(&storage, &topition).await?);
+
+    // the partition reports an empty log
+    let stage = storage.offset_stage(&topition).await?;
+    assert_eq!(0, stage.log_start());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn default_retention_keeps_recent_records() -> Result<(), Error> {
+    let _guard = init_tracing()?;
+
+    let storage = memory_storage().await?;
+
+    // cleanup.policy=delete with no retention.ms falls back to the 7 day default
+    create_topic(
+        &storage,
+        "defaulted",
+        vec![
+            CreatableTopicConfig::default()
+                .name("cleanup.policy".into())
+                .value(Some("delete".into())),
+        ],
+    )
+    .await?;
+
+    let topition = Topition::new("defaulted", 0);
+
+    produce_three(&storage, &topition).await?;
+
+    assert_eq!(3, fetch_len(&storage, &topition).await?);
+
+    // an hour into the future is still well inside the 7 day window
+    let later = SystemTime::now()
+        .checked_add(Duration::from_hours(1))
+        .expect("an hour ahead");
+    storage.maintain(later).await?;
+
+    assert_eq!(3, fetch_len(&storage, &topition).await?);
+
+    // eight days into the future is past the default retention
+    let later = SystemTime::now()
+        .checked_add(Duration::from_hours(8 * 24))
+        .expect("eight days ahead");
+    storage.maintain(later).await?;
+
+    assert_eq!(0, fetch_len(&storage, &topition).await?);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn without_delete_policy_records_are_retained() -> Result<(), Error> {
+    let _guard = init_tracing()?;
+
+    let storage = memory_storage().await?;
+
+    // no cleanup.policy: maintenance must never drop records
+    create_topic(&storage, "forever", vec![]).await?;
+
+    let topition = Topition::new("forever", 0);
+
+    produce_three(&storage, &topition).await?;
+
+    assert_eq!(3, fetch_len(&storage, &topition).await?);
+
+    let later = SystemTime::now()
+        .checked_add(Duration::from_hours(100 * 24))
+        .expect("a hundred days ahead");
+    storage.maintain(later).await?;
+
+    assert_eq!(3, fetch_len(&storage, &topition).await?);
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #649. The dynostore backends (s3://, memory://) ignored `cleanup.policy`: `maintain()` only ran lake maintenance and `delete_records()` was a `todo!()`. Data accumulated indefinitely on S3 despite a configured retention.

`delete` (retention): `maintain()` now drops batch files older than `retention.ms` (7 day default, matching the SQL backends), keyed on the object's `last_modified` (append time) so no per-batch GET or per-produce bookkeeping is needed — O(1) per produce, scalable to large partitions. Expired batches are removed concurrently via `delete_stream` and the log start offset (`watermark.low`) advances to the oldest survivor.

`compact`: walking batches newest-first, drop every record whose key reappears in a more recent batch (and earlier duplicates within a batch), reusing `inflated::Batch::compact`. Emptied batch files are deleted, partially compacted ones rewritten in place with offsets preserved.

`delete_records()` is implemented (was a panic) sharing the same primitives.

Tests (memory backend == dynostore code, no infra):
- tansu-storage/tests/policy_delete.rs
- tansu-storage/tests/policy_compact.rs (incl. multi-record rewrite)
- un-ignore delete_records and broker in_memory::compact_only

Known limitations: retention uses append-time not record CreateTime; compact rescans every batch per maintenance tick (no dirty tracking). The shared broker delete_only / delete_no_retention_ms_only tests stay ignored — they assume SQL-style record coalescing into one batch, which the one-file-per-produce dynostore model does not do.