### PR TITLE
fix(storage): stop read_committed from reading past the last stable offset

### DIFF
--- a/tansu-storage/src/limbo.rs
+++ b/tansu-storage/src/limbo.rs
@@ -1743,7 +1743,7 @@ impl Storage for Engine {
             .unwrap_or_default();
 
         let last_stable = row
-            .get_value(1)
+            .get_value(2)
             .map(|value| value.as_integer().copied())
             .inspect_err(|err| error!(?topition, ?err))?
             .unwrap_or(high_watermark);
@@ -4217,6 +4217,105 @@ mod tests {
             .create_topic(creatable_topic, false)
             .await
             .inspect(|uuid| debug!(?uuid))?;
+
+        Ok(())
+    }
+
+    /// An open (uncommitted) transaction must pin the read_committed last stable
+    /// offset below the high watermark. Regressed when `offset_stage` read the
+    /// high-watermark column instead of the stable-offset column, so
+    /// `read_committed` consumers saw uncommitted records.
+    ///
+    /// `#[ignore]`d like every other engine-level test here: turso/limbo cannot
+    /// yet run the full produce flow in CI. Run manually against turso with
+    /// `cargo nextest run --features turso -- --ignored`.
+    #[ignore]
+    #[tokio::test]
+    async fn read_committed_last_stable_offset_pinned_by_open_transaction() -> Result<()> {
+        use tansu_sans_io::add_partitions_to_txn_request::AddPartitionsToTxnTopic;
+
+        let _guard = init_tracing()?;
+
+        let temp_dir = tempdir().inspect(|temporary| debug!(?temporary))?;
+        let file_path = temp_dir.path().join("tansu.db");
+
+        let storage = Url::parse(&format!("file://{}", file_path.display()))?;
+        let cluster = "tansu";
+        let node = 12321;
+
+        let engine = Engine::builder()
+            .advertised_listener(Url::parse("tcp://127.0.0.1:9092")?)
+            .cluster(cluster.to_owned())
+            .storage(storage)
+            .node(node)
+            .build()
+            .await?;
+
+        engine
+            .register_broker(BrokerRegistrationRequest {
+                broker_id: node,
+                cluster_id: cluster.to_owned(),
+                incarnation_id: Uuid::new_v4(),
+                rack: None,
+            })
+            .await?;
+
+        _ = engine
+            .create_topic(
+                CreatableTopic::default()
+                    .name("t".into())
+                    .num_partitions(1)
+                    .replication_factor(1)
+                    .assignments(Some([].into()))
+                    .configs(Some([].into())),
+                false,
+            )
+            .await?;
+
+        let topition = Topition::new("t", 0);
+
+        // a transactional producer begins a transaction and produces, never commits
+        let producer = engine
+            .init_producer(Some("tx"), 10_000, Some(-1), Some(-1))
+            .await?;
+
+        _ = engine
+            .txn_add_partitions(TxnAddPartitionsRequest::VersionZeroToThree {
+                transaction_id: "tx".into(),
+                producer_id: producer.id,
+                producer_epoch: producer.epoch,
+                topics: vec![
+                    AddPartitionsToTxnTopic::default()
+                        .name("t".into())
+                        .partitions(Some(vec![0])),
+                ],
+            })
+            .await?;
+
+        let batch = inflated::Batch::builder()
+            .record(Record::builder().value(Bytes::from_static(b"uncommitted").into()))
+            .attributes(BatchAttribute::default().transaction(true).into())
+            .producer_id(producer.id)
+            .producer_epoch(producer.epoch)
+            .base_sequence(0)
+            .build()
+            .and_then(TryInto::try_into)?;
+
+        _ = engine.produce(Some("tx"), &topition, batch).await?;
+
+        let stage = engine.offset_stage(&topition).await?;
+
+        assert!(
+            stage.high_watermark > 0,
+            "the uncommitted record should advance the high watermark"
+        );
+        assert!(
+            stage.last_stable < stage.high_watermark,
+            "an open transaction must pin last_stable below the high watermark \
+             (last_stable={}, high_watermark={})",
+            stage.last_stable,
+            stage.high_watermark,
+        );
 
         Ok(())
     }

--- a/tansu-storage/src/lite.rs
+++ b/tansu-storage/src/lite.rs
@@ -2989,7 +2989,7 @@ impl Storage for Delegate {
             .unwrap_or_default();
 
         let last_stable = row
-            .get::<Option<i64>>(1)
+            .get::<Option<i64>>(2)
             .inspect_err(|err| error!(?topition, ?err))?
             .unwrap_or(high_watermark);
 
@@ -5476,5 +5476,120 @@ mod tests {
                     env!("CARGO_CRATE_NAME")
                 )
             })
+    }
+
+    fn txn_batch(producer_id: i64) -> deflated::Batch {
+        inflated::Batch::builder()
+            .record(Record::builder().value(Bytes::from_static(b"x").into()))
+            .attributes(BatchAttribute::default().transaction(true).into())
+            .producer_id(producer_id)
+            .producer_epoch(0)
+            .base_sequence(0)
+            .last_offset_delta(0)
+            .build()
+            .and_then(TryInto::try_into)
+            .expect("deflated txn batch")
+    }
+
+    /// An open (uncommitted) transaction must pin the read_committed last stable
+    /// offset below the high watermark. Regressed when `offset_stage` read the
+    /// high-watermark column instead of the stable-offset column, so
+    /// `read_committed` consumers saw uncommitted records.
+    #[tokio::test]
+    async fn read_committed_last_stable_offset_pinned_by_open_transaction() -> Result<()> {
+        use tansu_sans_io::add_partitions_to_txn_request::AddPartitionsToTxnTopic;
+
+        let _guard = init_tracing()?;
+
+        // lite's build() resolves the URL path relative to the crate dir (it
+        // strips the leading "/" and pushes onto cwd), so use a crate-local db
+        // file. A tempdir won't work here. The guard removes the file (and its
+        // WAL/SHM sidecars) on drop -- including on panic -- so no artifacts are
+        // left behind, while the up-front removal keeps re-runs deterministic.
+        struct DbFileGuard(&'static str);
+        impl Drop for DbFileGuard {
+            fn drop(&mut self) {
+                for suffix in ["", "-wal", "-shm"] {
+                    let _ = std::fs::remove_file(format!("{}{suffix}", self.0));
+                }
+            }
+        }
+
+        let db_file = "read-committed-last-stable-offset-test.db";
+        let _db_file_guard = DbFileGuard(db_file);
+        for suffix in ["", "-wal", "-shm"] {
+            let _ = std::fs::remove_file(format!("{db_file}{suffix}"));
+        }
+        let storage = Url::parse(&format!("file:///{db_file}"))?;
+        let cluster = "tansu";
+        let node = 12321;
+
+        let engine = Engine::builder()
+            .advertised_listener(Url::parse("tcp://127.0.0.1:9092")?)
+            .cluster(cluster.to_owned())
+            .storage(storage)
+            .node(node)
+            .build()
+            .await?;
+
+        engine
+            .register_broker(BrokerRegistrationRequest {
+                broker_id: node,
+                cluster_id: cluster.to_owned(),
+                incarnation_id: Uuid::new_v4(),
+                rack: None,
+            })
+            .await?;
+
+        _ = engine
+            .create_topic(
+                CreatableTopic::default()
+                    .name("t".into())
+                    .num_partitions(1)
+                    .replication_factor(1)
+                    .assignments(Some([].into()))
+                    .configs(Some([].into())),
+                false,
+            )
+            .await?;
+
+        // a transactional producer begins a transaction and produces, never commits
+        let producer = engine
+            .init_producer(Some("tx"), 0, Some(-1), Some(-1))
+            .await?;
+        let pid = producer.id;
+
+        _ = engine
+            .txn_add_partitions(TxnAddPartitionsRequest::VersionZeroToThree {
+                transaction_id: "tx".into(),
+                producer_id: pid,
+                producer_epoch: 0,
+                topics: vec![
+                    AddPartitionsToTxnTopic::default()
+                        .name("t".into())
+                        .partitions(Some(vec![0])),
+                ],
+            })
+            .await?;
+
+        _ = engine
+            .produce(Some("tx"), &Topition::new("t", 0), txn_batch(pid))
+            .await?;
+
+        let stage = engine.offset_stage(&Topition::new("t", 0)).await?;
+
+        assert!(
+            stage.high_watermark > 0,
+            "the uncommitted record should advance the high watermark"
+        );
+        assert!(
+            stage.last_stable < stage.high_watermark,
+            "an open transaction must pin last_stable below the high watermark \
+             (last_stable={}, high_watermark={})",
+            stage.last_stable,
+            stage.high_watermark,
+        );
+
+        Ok(())
     }
 }

--- a/tansu-storage/src/pg.rs
+++ b/tansu-storage/src/pg.rs
@@ -2086,7 +2086,7 @@ impl Storage for Postgres {
             .unwrap_or_default();
 
         let last_stable = row
-            .try_get::<_, Option<i64>>(1)
+            .try_get::<_, Option<i64>>(2)
             .inspect_err(|err| error!(?topition, ?err))?
             .unwrap_or(high_watermark);
 
@@ -3775,3 +3775,118 @@ static SQL_ERROR: LazyLock<Counter<u64>> = LazyLock::new(|| {
         .with_description("The SQL error count")
         .build()
 });
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::distr::Alphanumeric;
+    use tansu_sans_io::add_partitions_to_txn_request::AddPartitionsToTxnTopic;
+
+    // mirrors tansu-broker/tests/common/mod.rs storage_container(StorageType::Postgres)
+    const CONNECTION: &str = "postgres://postgres:postgres@localhost";
+
+    fn alphanumeric_string(length: usize) -> String {
+        rng()
+            .sample_iter(&Alphanumeric)
+            .take(length)
+            .map(char::from)
+            .collect()
+    }
+
+    /// An open (uncommitted) transaction must pin the read_committed last stable
+    /// offset below the high watermark. Regressed when `offset_stage` read the
+    /// high-watermark column instead of the stable-offset column, so
+    /// `read_committed` consumers saw uncommitted records.
+    #[tokio::test]
+    async fn read_committed_last_stable_offset_pinned_by_open_transaction() -> Result<()> {
+        let cluster = alphanumeric_string(15);
+
+        let storage = Postgres::builder(CONNECTION)?
+            .cluster(cluster.as_str())
+            .node(rng().random_range(0..i32::MAX))
+            .build();
+
+        // Probe connectivity explicitly: only a genuinely unreachable postgres
+        // should skip. Any later schema/query error must fail the test.
+        if let Err(err) = storage.connection().await {
+            eprintln!(
+                "skipping read_committed_last_stable_offset_pinned_by_open_transaction: {err:?}"
+            );
+            return Ok(());
+        }
+
+        storage
+            .register_broker(BrokerRegistrationRequest {
+                broker_id: 111,
+                cluster_id: cluster.clone(),
+                incarnation_id: Uuid::now_v7(),
+                rack: None,
+            })
+            .await?;
+
+        let topic_name = alphanumeric_string(15);
+        let num_partitions = 1;
+
+        _ = storage
+            .create_topic(
+                CreatableTopic::default()
+                    .name(topic_name.clone())
+                    .num_partitions(num_partitions)
+                    .replication_factor(0)
+                    .assignments(Some([].into()))
+                    .configs(Some([].into())),
+                false,
+            )
+            .await?;
+
+        let topition = Topition::new(topic_name.clone(), 0);
+
+        // a transactional producer begins a transaction and produces, never commits
+        let transaction_id = alphanumeric_string(10);
+        let producer = storage
+            .init_producer(Some(transaction_id.as_str()), 10_000, Some(-1), Some(-1))
+            .await?;
+
+        _ = storage
+            .txn_add_partitions(TxnAddPartitionsRequest::VersionZeroToThree {
+                transaction_id: transaction_id.clone(),
+                producer_id: producer.id,
+                producer_epoch: producer.epoch,
+                topics: vec![
+                    AddPartitionsToTxnTopic::default()
+                        .name(topic_name.clone())
+                        .partitions(Some((0..num_partitions).collect())),
+                ],
+            })
+            .await?;
+
+        let batch = Batch::builder()
+            .record(Record::builder().value(Bytes::from_static(b"uncommitted").into()))
+            .attributes(BatchAttribute::default().transaction(true).into())
+            .producer_id(producer.id)
+            .producer_epoch(producer.epoch)
+            .base_sequence(0)
+            .build()
+            .and_then(TryInto::try_into)?;
+
+        _ = storage
+            .produce(Some(transaction_id.as_str()), &topition, batch)
+            .await?;
+
+        let stage = storage.offset_stage(&topition).await?;
+
+        assert!(
+            stage.high_watermark > 0,
+            "the uncommitted record should advance the high watermark"
+        );
+        assert!(
+            stage.last_stable < stage.high_watermark,
+            "an open transaction must pin last_stable below the high watermark \
+             (last_stable={}, high_watermark={})",
+            stage.last_stable,
+            stage.high_watermark,
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
The watermark query selects three values:
    select w.low, w.high, s.offset

For the read_committed boundary (last_stable), offset_stage picked w.high -- the end of the log -- instead of s.offset, the stable offset up to which everything is committed. So read_committed consumers were handed the end of the log and could read records from transactions that hadn't committed yet.

Read s.offset instead on all three backends (Postgres, libSQL, Turso), with a regression test on each (turso one is  disabled like other tests until turso is stablized)