### PR TITLE
refactor(storage): split the timeout sweep into maintain_transactions

### DIFF
--- a/tansu-broker/src/broker.rs
+++ b/tansu-broker/src/broker.rs
@@ -39,7 +39,7 @@ use tansu_storage::{ArcDynStorage, BrokerRegistrationRequest, Storage, StorageCo
 use tokio::{
     net::TcpListener,
     signal::unix::{SignalKind, signal},
-    task::JoinSet,
+    task::{AbortHandle, JoinSet},
     time::{self, Instant, sleep},
 };
 use tokio_rustls::TlsAcceptor;
@@ -62,6 +62,7 @@ pub struct Broker<G, S> {
     tls_server_config: Option<Arc<ServerConfig>>,
     silent: bool,
     maintenance_interval: Option<Duration>,
+    transaction_maintenance_interval: Option<Duration>,
 
     cancellation: CancellationToken,
 }
@@ -96,6 +97,7 @@ where
             silent: false,
 
             maintenance_interval: None,
+            transaction_maintenance_interval: None,
 
             cancellation: CancellationToken::new(),
         }
@@ -240,6 +242,21 @@ where
         let mut interval =
             time::interval(self.maintenance_interval.unwrap_or(Duration::from_mins(10)));
 
+        let mut txn_interval = time::interval(
+            self.transaction_maintenance_interval
+                .unwrap_or(Duration::from_secs(10)),
+        );
+
+        // Periodic sweeps: skip missed ticks rather than firing them in a burst.
+        interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+        txn_interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+
+        // Track the in-flight sweep per interval so a sweep slower than its
+        // interval can't overlap itself or pile up: skip the tick while the
+        // previous sweep is still running.
+        let mut maintenance_sweep: Option<AbortHandle> = None;
+        let mut txn_sweep: Option<AbortHandle> = None;
+
         let mut set = JoinSet::new();
 
         let m = MultiProgress::new();
@@ -332,20 +349,49 @@ where
                 }
 
                 _ = interval.tick() => {
-                    let storage = self.storage.clone();
+                    if maintenance_sweep.as_ref().is_some_and(|handle| !handle.is_finished()) {
+                        debug!("maintain still in flight; skipping tick");
+                    } else {
+                        let storage = self.storage.clone();
 
+                        let handle = set.spawn(async move {
+                            let span = span!(Level::DEBUG, "maintenance");
 
-                    let handle = set.spawn(async move {
-                        let span = span!(Level::DEBUG, "maintenance");
+                            async move {
+                                if let Err(err) = storage.maintain(SystemTime::now()).await {
+                                    debug!(?err);
+                                }
+                            }
+                            .instrument(span)
+                            .await
+                        });
 
-                        async move {
-                            _ = storage.maintain(SystemTime::now()).await.inspect(|maintain|debug!(?maintain)).inspect_err(|err|debug!(?err)).ok();
+                        debug!(?handle);
+                        maintenance_sweep = Some(handle);
+                    }
+                }
 
-                        }.instrument(span).await
+                _ = txn_interval.tick() => {
+                    if txn_sweep.as_ref().is_some_and(|handle| !handle.is_finished()) {
+                        debug!("maintain_transactions still in flight; skipping tick");
+                    } else {
+                        let storage = self.storage.clone();
 
-                    });
+                        let handle = set.spawn(async move {
+                            let span = span!(Level::DEBUG, "maintain_transactions");
 
-                    debug!(?handle);
+                            async move {
+                                if let Err(err) = storage.maintain_transactions(SystemTime::now()).await {
+                                    debug!(?err);
+                                }
+                            }
+                            .instrument(span)
+                            .await
+                        });
+
+                        debug!(?handle);
+                        txn_sweep = Some(handle);
+                    }
                 }
 
                 v = set.join_next(), if !set.is_empty() => {
@@ -384,6 +430,7 @@ pub struct Builder<N, C, I, A, S, L> {
     tls_server_config: Option<ServerConfig>,
     silent: bool,
     maintenance_interval: Option<Duration>,
+    transaction_maintenance_interval: Option<Duration>,
 
     cancellation: CancellationToken,
 }
@@ -399,6 +446,7 @@ type PhantomBuilder = Builder<
 
 impl<N, C, I, A, S, L> Builder<N, C, I, A, S, L> {
     const MAINTENANCE_INTERVAL: &str = "maintenance_interval";
+    const TRANSACTION_MAINTENANCE_INTERVAL: &str = "transaction_maintenance_interval";
 
     pub fn node_id(self, node_id: i32) -> Builder<i32, C, I, A, S, L> {
         Builder {
@@ -415,7 +463,7 @@ impl<N, C, I, A, S, L> Builder<N, C, I, A, S, L> {
             tls_server_config: self.tls_server_config,
             silent: self.silent,
             maintenance_interval: self.maintenance_interval,
-
+            transaction_maintenance_interval: self.transaction_maintenance_interval,
             cancellation: self.cancellation,
         }
     }
@@ -435,6 +483,7 @@ impl<N, C, I, A, S, L> Builder<N, C, I, A, S, L> {
             tls_server_config: self.tls_server_config,
             silent: self.silent,
             maintenance_interval: self.maintenance_interval,
+            transaction_maintenance_interval: self.transaction_maintenance_interval,
 
             cancellation: self.cancellation,
         }
@@ -455,6 +504,7 @@ impl<N, C, I, A, S, L> Builder<N, C, I, A, S, L> {
             tls_server_config: self.tls_server_config,
             silent: self.silent,
             maintenance_interval: self.maintenance_interval,
+            transaction_maintenance_interval: self.transaction_maintenance_interval,
 
             cancellation: self.cancellation,
         }
@@ -478,6 +528,7 @@ impl<N, C, I, A, S, L> Builder<N, C, I, A, S, L> {
             tls_server_config: self.tls_server_config,
             silent: self.silent,
             maintenance_interval: self.maintenance_interval,
+            transaction_maintenance_interval: self.transaction_maintenance_interval,
 
             cancellation: self.cancellation,
         }
@@ -492,10 +543,18 @@ impl<N, C, I, A, S, L> Builder<N, C, I, A, S, L> {
             }
         });
 
+        let transaction_maintenance_interval = storage.query_pairs().find_map(|(k, v)| {
+            if k == Self::TRANSACTION_MAINTENANCE_INTERVAL {
+                v.parse::<humantime::Duration>().map(Into::into).ok()
+            } else {
+                None
+            }
+        });
+
         let pairs = storage
             .query_pairs()
             .filter_map(|(k, v)| {
-                if k == Self::MAINTENANCE_INTERVAL {
+                if k == Self::MAINTENANCE_INTERVAL || k == Self::TRANSACTION_MAINTENANCE_INTERVAL {
                     None
                 } else {
                     Some((k.to_string(), v.to_string()))
@@ -509,7 +568,7 @@ impl<N, C, I, A, S, L> Builder<N, C, I, A, S, L> {
             _ = storage.query_pairs_mut().clear().extend_pairs(pairs);
         }
 
-        debug!(?maintenance_interval, %storage);
+        debug!(?maintenance_interval, ?transaction_maintenance_interval, %storage);
 
         Builder {
             node_id: self.node_id,
@@ -525,6 +584,7 @@ impl<N, C, I, A, S, L> Builder<N, C, I, A, S, L> {
             tls_server_config: self.tls_server_config,
             silent: self.silent,
             maintenance_interval,
+            transaction_maintenance_interval,
 
             cancellation: self.cancellation,
         }
@@ -547,6 +607,7 @@ impl<N, C, I, A, S, L> Builder<N, C, I, A, S, L> {
             tls_server_config: self.tls_server_config,
             silent: self.silent,
             maintenance_interval: self.maintenance_interval,
+            transaction_maintenance_interval: self.transaction_maintenance_interval,
 
             cancellation: self.cancellation,
         }
@@ -636,6 +697,7 @@ impl Builder<i32, String, Uuid, Url, Url, Url> {
 
             silent: self.silent,
             maintenance_interval: self.maintenance_interval,
+            transaction_maintenance_interval: self.transaction_maintenance_interval,
             cancellation: self.cancellation,
         })
     }

--- a/tansu-broker/tests/auth.rs
+++ b/tansu-broker/tests/auth.rs
@@ -1000,6 +1000,11 @@ impl Storage for Engine {
     }
 
     #[instrument(skip_all)]
+    async fn maintain_transactions(&self, _now: SystemTime) -> tansu_storage::Result<()> {
+        unimplemented!()
+    }
+
+    #[instrument(skip_all)]
     async fn cluster_id(&self) -> tansu_storage::Result<String> {
         unimplemented!()
     }

--- a/tansu-storage/src/batch.rs
+++ b/tansu-storage/src/batch.rs
@@ -624,6 +624,10 @@ where
         self.storage.maintain(now).await
     }
 
+    async fn maintain_transactions(&self, now: SystemTime) -> Result<()> {
+        self.storage.maintain_transactions(now).await
+    }
+
     async fn cluster_id(&self) -> Result<String> {
         self.storage.cluster_id().await
     }
@@ -935,6 +939,10 @@ mod tests {
         }
 
         async fn maintain(&self, _now: SystemTime) -> Result<()> {
+            unimplemented!()
+        }
+
+        async fn maintain_transactions(&self, _now: SystemTime) -> Result<()> {
             unimplemented!()
         }
 

--- a/tansu-storage/src/dynostore.rs
+++ b/tansu-storage/src/dynostore.rs
@@ -2675,6 +2675,10 @@ impl Storage for DynoStore {
         Ok(())
     }
 
+    async fn maintain_transactions(&self, _now: SystemTime) -> Result<()> {
+        Ok(())
+    }
+
     async fn cluster_id(&self) -> Result<String> {
         Ok(self.cluster.clone())
     }

--- a/tansu-storage/src/latency.rs
+++ b/tansu-storage/src/latency.rs
@@ -389,6 +389,12 @@ where
         self.storage.maintain(now).await
     }
 
+    async fn maintain_transactions(&self, now: SystemTime) -> Result<()> {
+        self.introduce_latency().await?;
+
+        self.storage.maintain_transactions(now).await
+    }
+
     async fn cluster_id(&self) -> Result<String> {
         self.introduce_latency().await?;
 

--- a/tansu-storage/src/lib.rs
+++ b/tansu-storage/src/lib.rs
@@ -1515,9 +1515,10 @@ pub trait Storage: Debug + Send + Sync + 'static {
     ) -> Result<ErrorCode>;
 
     /// Run periodic maintenance on this storage.
-    async fn maintain(&self, _now: SystemTime) -> Result<()> {
-        Ok(())
-    }
+    async fn maintain(&self, _now: SystemTime) -> Result<()>;
+
+    /// Abort transactions whose timeout has elapsed, releasing the Last Stable Offset they pin.
+    async fn maintain_transactions(&self, _now: SystemTime) -> Result<()>;
 
     async fn cluster_id(&self) -> Result<String>;
 
@@ -1768,6 +1769,10 @@ where
 
     async fn maintain(&self, now: SystemTime) -> Result<()> {
         self.as_ref().maintain(now).await
+    }
+
+    async fn maintain_transactions(&self, now: SystemTime) -> Result<()> {
+        self.as_ref().maintain_transactions(now).await
     }
 
     async fn cluster_id(&self) -> Result<String> {
@@ -2023,6 +2028,10 @@ where
 
     async fn maintain(&self, now: SystemTime) -> Result<()> {
         self.as_ref().maintain(now).await
+    }
+
+    async fn maintain_transactions(&self, now: SystemTime) -> Result<()> {
+        self.as_ref().maintain_transactions(now).await
     }
 
     async fn cluster_id(&self) -> Result<String> {
@@ -3540,6 +3549,39 @@ impl Storage for StorageContainer {
 
             #[cfg(feature = "turso")]
             Self::Turso(engine) => engine.maintain(now),
+        }
+        .await
+        .inspect(|maintain| {
+            debug!(?maintain);
+            STORAGE_CONTAINER_REQUESTS.add(1, &attributes);
+        })
+        .inspect_err(|err| {
+            debug!(?err);
+            STORAGE_CONTAINER_ERRORS.add(1, &attributes);
+        })
+    }
+
+    #[instrument(skip_all)]
+    async fn maintain_transactions(&self, now: SystemTime) -> Result<()> {
+        let attributes = [KeyValue::new("method", "maintain_transactions")];
+
+        match self {
+            #[cfg(feature = "dynostore")]
+            Self::DynoStore(engine) => engine.maintain_transactions(now),
+
+            #[cfg(feature = "libsql")]
+            Self::Lite(engine) => engine.maintain_transactions(now),
+
+            Self::Null(engine) => engine.maintain_transactions(now),
+
+            #[cfg(feature = "postgres")]
+            Self::Postgres(engine) => engine.maintain_transactions(now),
+
+            #[cfg(feature = "slatedb")]
+            Self::Slate(engine) => engine.maintain_transactions(now),
+
+            #[cfg(feature = "turso")]
+            Self::Turso(engine) => engine.maintain_transactions(now),
         }
         .await
         .inspect(|maintain| {

--- a/tansu-storage/src/limbo.rs
+++ b/tansu-storage/src/limbo.rs
@@ -3632,6 +3632,10 @@ impl Storage for Engine {
         Ok(())
     }
 
+    async fn maintain_transactions(&self, _now: SystemTime) -> Result<()> {
+        Ok(())
+    }
+
     async fn cluster_id(&self) -> Result<String> {
         Ok(self.cluster.clone())
     }

--- a/tansu-storage/src/lite.rs
+++ b/tansu-storage/src/lite.rs
@@ -1996,6 +1996,17 @@ impl Storage for Engine {
     }
 
     #[instrument(skip_all)]
+    async fn maintain_transactions(&self, now: SystemTime) -> Result<()> {
+        let start = SystemTime::now();
+        self.inner.maintain_transactions(now).await.inspect(|_| {
+            ENGINE_REQUEST_DURATION.record(
+                elapsed_millis(start),
+                &[KeyValue::new("operation", "maintain_transactions")],
+            )
+        })
+    }
+
+    #[instrument(skip_all)]
     async fn cluster_id(&self) -> Result<String> {
         let start = SystemTime::now();
         self.inner.cluster_id().await.inspect(|_| {
@@ -4697,6 +4708,10 @@ impl Storage for Delegate {
                 &[KeyValue::new("operation", "txn_end")],
             )
         })
+    }
+
+    async fn maintain_transactions(&self, _now: SystemTime) -> Result<()> {
+        Ok(())
     }
 
     async fn maintain(&self, now: SystemTime) -> Result<()> {

--- a/tansu-storage/src/null.rs
+++ b/tansu-storage/src/null.rs
@@ -495,6 +495,11 @@ impl Storage for Engine {
     }
 
     #[instrument(skip_all)]
+    async fn maintain_transactions(&self, _now: SystemTime) -> Result<()> {
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
     async fn cluster_id(&self) -> Result<String> {
         Ok(self.cluster.clone())
     }

--- a/tansu-storage/src/pg.rs
+++ b/tansu-storage/src/pg.rs
@@ -3658,6 +3658,10 @@ impl Storage for Postgres {
         Ok(())
     }
 
+    async fn maintain_transactions(&self, _now: SystemTime) -> Result<()> {
+        Ok(())
+    }
+
     async fn delete_user_scram_credential(
         &self,
         user: &str,

--- a/tansu-storage/src/proxy.rs
+++ b/tansu-storage/src/proxy.rs
@@ -523,6 +523,10 @@ where
         self.storage.maintain(now).await
     }
 
+    async fn maintain_transactions(&self, now: SystemTime) -> Result<()> {
+        self.storage.maintain_transactions(now).await
+    }
+
     async fn cluster_id(&self) -> Result<String> {
         self.storage.cluster_id().await
     }

--- a/tansu-storage/src/service.rs
+++ b/tansu-storage/src/service.rs
@@ -188,6 +188,7 @@ pub enum Request {
         committed: bool,
     },
     Maintain(SystemTime),
+    MaintainTransactions(SystemTime),
     ClusterId,
     Node,
     AdvertisedListener,
@@ -227,6 +228,7 @@ impl Display for Request {
             Self::ListGroups(_) => f.write_str("ListGroups"),
             Self::ListOffsets { .. } => f.write_str("ListOffsets"),
             Self::Maintain(_) => f.write_str("Maintain"),
+            Self::MaintainTransactions(_) => f.write_str("MaintainTransactions"),
             Self::Metadata(_) => f.write_str("Metadata"),
             Self::Node => f.write_str("Node"),
             Self::OffsetCommit { .. } => f.write_str("OffsetCommit"),
@@ -267,6 +269,7 @@ pub enum Response {
     ListGroups(Result<Vec<ListedGroup>>),
     ListOffsets(Result<Vec<(Topition, ListOffsetResponse)>>),
     Maintain(Result<()>),
+    MaintainTransactions(Result<()>),
     Metadata(Result<MetadataResponse>),
     Node(Result<i32>),
     OffsetCommit(Result<Vec<(Topition, ErrorCode)>>),
@@ -1069,6 +1072,20 @@ impl Storage for RequestChannelService {
     }
 
     #[instrument(skip_all)]
+    async fn maintain_transactions(&self, now: SystemTime) -> Result<()> {
+        self.serve(Context::default(), Request::MaintainTransactions(now))
+            .await
+            .and_then(|response| {
+                if let Response::MaintainTransactions(inner) = response {
+                    inner.map_err(Into::into)
+                } else {
+                    Err(Error::UnexpectedServiceResponse(Box::new(response)).into())
+                }
+            })
+            .map_err(Into::into)
+    }
+
+    #[instrument(skip_all)]
     async fn cluster_id(&self) -> Result<String> {
         self.serve(Context::default(), Request::ClusterId)
             .await
@@ -1458,6 +1475,9 @@ where
                     .await,
             )),
             Request::Maintain(now) => Ok(Response::Maintain(self.storage.maintain(now).await)),
+            Request::MaintainTransactions(now) => Ok(Response::MaintainTransactions(
+                self.storage.maintain_transactions(now).await,
+            )),
             Request::ClusterId => Ok(Response::ClusterId(self.storage.cluster_id().await)),
             Request::Node => Ok(Response::Node(self.storage.node().await)),
             Request::AdvertisedListener => Ok(Response::AdvertisedListener(

--- a/tansu-storage/src/slate/storage.rs
+++ b/tansu-storage/src/slate/storage.rs
@@ -2683,6 +2683,10 @@ impl Storage for Engine {
         Ok(())
     }
 
+    async fn maintain_transactions(&self, _now: SystemTime) -> Result<()> {
+        Ok(())
+    }
+
     async fn cluster_id(&self) -> Result<String> {
         Ok(self.cluster.clone())
     }


### PR DESCRIPTION
    refactor(storage): split the timeout sweep into maintain_transactions
    
    Move the transaction-timeout sweep out of Storage::maintain into a new
    Storage::maintain_transactions(now), run by the broker as its own task on
    its own interval.
    
    General maintenance defaults to 10 minutes -- too slow to release the
    Last Stable Offset an abandoned transaction pins. The sweep gets its own
    transaction_maintenance_interval (storage-URL query param), defaulting to
    10s to match apache Kafka's
    transaction.abort.timed.out.transaction.cleanup.interval.ms.
    
    Both intervals skip missed ticks and guard against overlap (an
    AbortHandle per sweep), so a sweep slower than its interval can't run
    twice at once or pile up. StorageContainer::maintain_transactions records
    the same request/error metrics and span as the other dispatch methods.
    
    all backends for now return Ok().