### PR TITLE
feat(storage): add Storage::aborted_transactions trait and stubs

### DIFF
--- a/tansu-broker/tests/auth.rs
+++ b/tansu-broker/tests/auth.rs
@@ -39,7 +39,7 @@ use tansu_sans_io::{
     describe_cluster_response::DescribeClusterBroker,
     describe_configs_response::DescribeConfigsResult,
     describe_topic_partitions_response::DescribeTopicPartitionsResponseTopic,
-    incremental_alter_configs_request::AlterConfigsResource,
+    fetch_response::AbortedTransaction, incremental_alter_configs_request::AlterConfigsResource,
     incremental_alter_configs_response::AlterConfigsResourceResponse,
     list_groups_response::ListedGroup, record::deflated::Batch,
     txn_offset_commit_response::TxnOffsetCommitResponseTopic,
@@ -1001,6 +1001,16 @@ impl Storage for Engine {
 
     #[instrument(skip_all)]
     async fn maintain_transactions(&self, _now: SystemTime) -> tansu_storage::Result<()> {
+        unimplemented!()
+    }
+
+    #[instrument(skip_all)]
+    async fn aborted_transactions(
+        &self,
+        _topition: &Topition,
+        _offset: i64,
+        _last_stable_offset: i64,
+    ) -> tansu_storage::Result<Vec<AbortedTransaction>> {
         unimplemented!()
     }
 

--- a/tansu-storage/src/batch.rs
+++ b/tansu-storage/src/batch.rs
@@ -35,6 +35,7 @@ use tansu_sans_io::{
     describe_cluster_response::DescribeClusterBroker,
     describe_configs_response::DescribeConfigsResult,
     describe_topic_partitions_response::DescribeTopicPartitionsResponseTopic,
+    fetch_response::AbortedTransaction,
     incremental_alter_configs_request::AlterConfigsResource,
     incremental_alter_configs_response::AlterConfigsResourceResponse,
     list_groups_response::ListedGroup,
@@ -628,6 +629,17 @@ where
         self.storage.maintain_transactions(now).await
     }
 
+    async fn aborted_transactions(
+        &self,
+        topition: &Topition,
+        offset: i64,
+        last_stable_offset: i64,
+    ) -> Result<Vec<AbortedTransaction>> {
+        self.storage
+            .aborted_transactions(topition, offset, last_stable_offset)
+            .await
+    }
+
     async fn cluster_id(&self) -> Result<String> {
         self.storage.cluster_id().await
     }
@@ -943,6 +955,15 @@ mod tests {
         }
 
         async fn maintain_transactions(&self, _now: SystemTime) -> Result<()> {
+            unimplemented!()
+        }
+
+        async fn aborted_transactions(
+            &self,
+            _topition: &Topition,
+            _offset: i64,
+            _last_stable_offset: i64,
+        ) -> Result<Vec<AbortedTransaction>> {
             unimplemented!()
         }
 

--- a/tansu-storage/src/dynostore.rs
+++ b/tansu-storage/src/dynostore.rs
@@ -56,6 +56,7 @@ use tansu_sans_io::{
     describe_topic_partitions_response::{
         DescribeTopicPartitionsResponsePartition, DescribeTopicPartitionsResponseTopic,
     },
+    fetch_response::AbortedTransaction,
     incremental_alter_configs_request::{AlterConfigsResource, AlterableConfig},
     incremental_alter_configs_response::AlterConfigsResourceResponse,
     list_groups_response::ListedGroup,
@@ -2677,6 +2678,15 @@ impl Storage for DynoStore {
 
     async fn maintain_transactions(&self, _now: SystemTime) -> Result<()> {
         Ok(())
+    }
+
+    async fn aborted_transactions(
+        &self,
+        _topition: &Topition,
+        _offset: i64,
+        _last_stable_offset: i64,
+    ) -> Result<Vec<AbortedTransaction>> {
+        Ok(vec![])
     }
 
     async fn cluster_id(&self) -> Result<String> {

--- a/tansu-storage/src/latency.rs
+++ b/tansu-storage/src/latency.rs
@@ -28,7 +28,7 @@ use tansu_sans_io::{
     describe_cluster_response::DescribeClusterBroker,
     describe_configs_response::DescribeConfigsResult,
     describe_topic_partitions_response::DescribeTopicPartitionsResponseTopic,
-    incremental_alter_configs_request::AlterConfigsResource,
+    fetch_response::AbortedTransaction, incremental_alter_configs_request::AlterConfigsResource,
     incremental_alter_configs_response::AlterConfigsResourceResponse,
     list_groups_response::ListedGroup, record::deflated,
     txn_offset_commit_response::TxnOffsetCommitResponseTopic,
@@ -393,6 +393,19 @@ where
         self.introduce_latency().await?;
 
         self.storage.maintain_transactions(now).await
+    }
+
+    async fn aborted_transactions(
+        &self,
+        topition: &Topition,
+        offset: i64,
+        last_stable_offset: i64,
+    ) -> Result<Vec<AbortedTransaction>> {
+        self.introduce_latency().await?;
+
+        self.storage
+            .aborted_transactions(topition, offset, last_stable_offset)
+            .await
     }
 
     async fn cluster_id(&self) -> Result<String> {

--- a/tansu-storage/src/lib.rs
+++ b/tansu-storage/src/lib.rs
@@ -176,6 +176,7 @@ use tansu_sans_io::{
     describe_topic_partitions_request::{Cursor, TopicRequest},
     describe_topic_partitions_response::DescribeTopicPartitionsResponseTopic,
     fetch_request::FetchTopic,
+    fetch_response::AbortedTransaction,
     incremental_alter_configs_request::AlterConfigsResource,
     incremental_alter_configs_response::AlterConfigsResourceResponse,
     join_group_response::JoinGroupResponseMember,
@@ -1520,6 +1521,16 @@ pub trait Storage: Debug + Send + Sync + 'static {
     /// Abort transactions whose timeout has elapsed, releasing the Last Stable Offset they pin.
     async fn maintain_transactions(&self, _now: SystemTime) -> Result<()>;
 
+    /// Aborted transactions overlapping `[offset, last_stable_offset)`, reporting which producer
+    /// ranges a `read_committed` Fetch client should discard. Postgres implements this; other
+    /// backends return `Ok(vec![])` or forward to an inner storage.
+    async fn aborted_transactions(
+        &self,
+        _topition: &Topition,
+        _offset: i64,
+        _last_stable_offset: i64,
+    ) -> Result<Vec<AbortedTransaction>>;
+
     async fn cluster_id(&self) -> Result<String>;
 
     async fn node(&self) -> Result<i32>;
@@ -1773,6 +1784,17 @@ where
 
     async fn maintain_transactions(&self, now: SystemTime) -> Result<()> {
         self.as_ref().maintain_transactions(now).await
+    }
+
+    async fn aborted_transactions(
+        &self,
+        topition: &Topition,
+        offset: i64,
+        last_stable_offset: i64,
+    ) -> Result<Vec<AbortedTransaction>> {
+        self.as_ref()
+            .aborted_transactions(topition, offset, last_stable_offset)
+            .await
     }
 
     async fn cluster_id(&self) -> Result<String> {
@@ -2032,6 +2054,17 @@ where
 
     async fn maintain_transactions(&self, now: SystemTime) -> Result<()> {
         self.as_ref().maintain_transactions(now).await
+    }
+
+    async fn aborted_transactions(
+        &self,
+        topition: &Topition,
+        offset: i64,
+        last_stable_offset: i64,
+    ) -> Result<Vec<AbortedTransaction>> {
+        self.as_ref()
+            .aborted_transactions(topition, offset, last_stable_offset)
+            .await
     }
 
     async fn cluster_id(&self) -> Result<String> {
@@ -3586,6 +3619,52 @@ impl Storage for StorageContainer {
         .await
         .inspect(|maintain| {
             debug!(?maintain);
+            STORAGE_CONTAINER_REQUESTS.add(1, &attributes);
+        })
+        .inspect_err(|err| {
+            debug!(?err);
+            STORAGE_CONTAINER_ERRORS.add(1, &attributes);
+        })
+    }
+
+    #[instrument(skip_all)]
+    async fn aborted_transactions(
+        &self,
+        topition: &Topition,
+        offset: i64,
+        last_stable_offset: i64,
+    ) -> Result<Vec<AbortedTransaction>> {
+        let attributes = [KeyValue::new("method", "aborted_transactions")];
+
+        match self {
+            #[cfg(feature = "dynostore")]
+            Self::DynoStore(engine) => {
+                engine.aborted_transactions(topition, offset, last_stable_offset)
+            }
+
+            #[cfg(feature = "libsql")]
+            Self::Lite(engine) => engine.aborted_transactions(topition, offset, last_stable_offset),
+
+            Self::Null(engine) => engine.aborted_transactions(topition, offset, last_stable_offset),
+
+            #[cfg(feature = "postgres")]
+            Self::Postgres(engine) => {
+                engine.aborted_transactions(topition, offset, last_stable_offset)
+            }
+
+            #[cfg(feature = "slatedb")]
+            Self::Slate(engine) => {
+                engine.aborted_transactions(topition, offset, last_stable_offset)
+            }
+
+            #[cfg(feature = "turso")]
+            Self::Turso(engine) => {
+                engine.aborted_transactions(topition, offset, last_stable_offset)
+            }
+        }
+        .await
+        .inspect(|aborted_transactions| {
+            debug!(?aborted_transactions);
             STORAGE_CONTAINER_REQUESTS.add(1, &attributes);
         })
         .inspect_err(|err| {

--- a/tansu-storage/src/limbo.rs
+++ b/tansu-storage/src/limbo.rs
@@ -55,6 +55,7 @@ use tansu_sans_io::{
     describe_topic_partitions_response::{
         DescribeTopicPartitionsResponsePartition, DescribeTopicPartitionsResponseTopic,
     },
+    fetch_response::AbortedTransaction,
     incremental_alter_configs_request::AlterConfigsResource,
     incremental_alter_configs_response::AlterConfigsResourceResponse,
     list_groups_response::ListedGroup,
@@ -3634,6 +3635,15 @@ impl Storage for Engine {
 
     async fn maintain_transactions(&self, _now: SystemTime) -> Result<()> {
         Ok(())
+    }
+
+    async fn aborted_transactions(
+        &self,
+        _topition: &Topition,
+        _offset: i64,
+        _last_stable_offset: i64,
+    ) -> Result<Vec<AbortedTransaction>> {
+        Ok(vec![])
     }
 
     async fn cluster_id(&self) -> Result<String> {

--- a/tansu-storage/src/lite.rs
+++ b/tansu-storage/src/lite.rs
@@ -64,6 +64,7 @@ use tansu_sans_io::{
     describe_topic_partitions_response::{
         DescribeTopicPartitionsResponsePartition, DescribeTopicPartitionsResponseTopic,
     },
+    fetch_response::AbortedTransaction,
     incremental_alter_configs_request::AlterConfigsResource,
     incremental_alter_configs_response::AlterConfigsResourceResponse,
     list_groups_response::ListedGroup,
@@ -2004,6 +2005,25 @@ impl Storage for Engine {
                 &[KeyValue::new("operation", "maintain_transactions")],
             )
         })
+    }
+
+    #[instrument(skip_all)]
+    async fn aborted_transactions(
+        &self,
+        topition: &Topition,
+        offset: i64,
+        last_stable_offset: i64,
+    ) -> Result<Vec<AbortedTransaction>> {
+        let start = SystemTime::now();
+        self.inner
+            .aborted_transactions(topition, offset, last_stable_offset)
+            .await
+            .inspect(|_| {
+                ENGINE_REQUEST_DURATION.record(
+                    elapsed_millis(start),
+                    &[KeyValue::new("operation", "aborted_transactions")],
+                )
+            })
     }
 
     #[instrument(skip_all)]
@@ -4712,6 +4732,15 @@ impl Storage for Delegate {
 
     async fn maintain_transactions(&self, _now: SystemTime) -> Result<()> {
         Ok(())
+    }
+
+    async fn aborted_transactions(
+        &self,
+        _topition: &Topition,
+        _offset: i64,
+        _last_stable_offset: i64,
+    ) -> Result<Vec<AbortedTransaction>> {
+        Ok(vec![])
     }
 
     async fn maintain(&self, now: SystemTime) -> Result<()> {

--- a/tansu-storage/src/null.rs
+++ b/tansu-storage/src/null.rs
@@ -31,6 +31,7 @@ use tansu_sans_io::{
     describe_topic_partitions_response::{
         DescribeTopicPartitionsResponsePartition, DescribeTopicPartitionsResponseTopic,
     },
+    fetch_response::AbortedTransaction,
     incremental_alter_configs_request::AlterConfigsResource,
     incremental_alter_configs_response::AlterConfigsResourceResponse,
     list_groups_response::ListedGroup,
@@ -497,6 +498,16 @@ impl Storage for Engine {
     #[instrument(skip_all)]
     async fn maintain_transactions(&self, _now: SystemTime) -> Result<()> {
         Ok(())
+    }
+
+    #[instrument(skip_all)]
+    async fn aborted_transactions(
+        &self,
+        _topition: &Topition,
+        _offset: i64,
+        _last_stable_offset: i64,
+    ) -> Result<Vec<AbortedTransaction>> {
+        Ok(vec![])
     }
 
     #[instrument(skip_all)]

--- a/tansu-storage/src/pg.rs
+++ b/tansu-storage/src/pg.rs
@@ -48,6 +48,7 @@ use tansu_sans_io::{
     describe_topic_partitions_response::{
         DescribeTopicPartitionsResponsePartition, DescribeTopicPartitionsResponseTopic,
     },
+    fetch_response::AbortedTransaction,
     incremental_alter_configs_request::AlterConfigsResource,
     incremental_alter_configs_response::AlterConfigsResourceResponse,
     list_groups_response::ListedGroup,
@@ -3660,6 +3661,15 @@ impl Storage for Postgres {
 
     async fn maintain_transactions(&self, _now: SystemTime) -> Result<()> {
         Ok(())
+    }
+
+    async fn aborted_transactions(
+        &self,
+        _topition: &Topition,
+        _offset: i64,
+        _last_stable_offset: i64,
+    ) -> Result<Vec<AbortedTransaction>> {
+        Ok(vec![])
     }
 
     async fn delete_user_scram_credential(

--- a/tansu-storage/src/proxy.rs
+++ b/tansu-storage/src/proxy.rs
@@ -28,7 +28,7 @@ use tansu_sans_io::{
     describe_cluster_response::DescribeClusterBroker,
     describe_configs_response::DescribeConfigsResult,
     describe_topic_partitions_response::DescribeTopicPartitionsResponseTopic,
-    incremental_alter_configs_request::AlterConfigsResource,
+    fetch_response::AbortedTransaction, incremental_alter_configs_request::AlterConfigsResource,
     incremental_alter_configs_response::AlterConfigsResourceResponse,
     list_groups_response::ListedGroup, record::deflated,
     txn_offset_commit_response::TxnOffsetCommitResponseTopic,
@@ -525,6 +525,17 @@ where
 
     async fn maintain_transactions(&self, now: SystemTime) -> Result<()> {
         self.storage.maintain_transactions(now).await
+    }
+
+    async fn aborted_transactions(
+        &self,
+        topition: &Topition,
+        offset: i64,
+        last_stable_offset: i64,
+    ) -> Result<Vec<AbortedTransaction>> {
+        self.storage
+            .aborted_transactions(topition, offset, last_stable_offset)
+            .await
     }
 
     async fn cluster_id(&self) -> Result<String> {

--- a/tansu-storage/src/service.rs
+++ b/tansu-storage/src/service.rs
@@ -80,7 +80,7 @@ use tansu_sans_io::{
     describe_cluster_response::DescribeClusterBroker,
     describe_configs_response::DescribeConfigsResult,
     describe_topic_partitions_response::DescribeTopicPartitionsResponseTopic,
-    incremental_alter_configs_request::AlterConfigsResource,
+    fetch_response::AbortedTransaction, incremental_alter_configs_request::AlterConfigsResource,
     incremental_alter_configs_response::AlterConfigsResourceResponse,
     list_groups_response::ListedGroup, record::deflated,
     txn_offset_commit_response::TxnOffsetCommitResponseTopic,
@@ -189,6 +189,11 @@ pub enum Request {
     },
     Maintain(SystemTime),
     MaintainTransactions(SystemTime),
+    AbortedTransactions {
+        topition: Topition,
+        offset: i64,
+        last_stable_offset: i64,
+    },
     ClusterId,
     Node,
     AdvertisedListener,
@@ -229,6 +234,7 @@ impl Display for Request {
             Self::ListOffsets { .. } => f.write_str("ListOffsets"),
             Self::Maintain(_) => f.write_str("Maintain"),
             Self::MaintainTransactions(_) => f.write_str("MaintainTransactions"),
+            Self::AbortedTransactions { .. } => f.write_str("AbortedTransactions"),
             Self::Metadata(_) => f.write_str("Metadata"),
             Self::Node => f.write_str("Node"),
             Self::OffsetCommit { .. } => f.write_str("OffsetCommit"),
@@ -270,6 +276,7 @@ pub enum Response {
     ListOffsets(Result<Vec<(Topition, ListOffsetResponse)>>),
     Maintain(Result<()>),
     MaintainTransactions(Result<()>),
+    AbortedTransactions(Result<Vec<AbortedTransaction>>),
     Metadata(Result<MetadataResponse>),
     Node(Result<i32>),
     OffsetCommit(Result<Vec<(Topition, ErrorCode)>>),
@@ -1086,6 +1093,32 @@ impl Storage for RequestChannelService {
     }
 
     #[instrument(skip_all)]
+    async fn aborted_transactions(
+        &self,
+        topition: &Topition,
+        offset: i64,
+        last_stable_offset: i64,
+    ) -> Result<Vec<AbortedTransaction>> {
+        self.serve(
+            Context::default(),
+            Request::AbortedTransactions {
+                topition: topition.clone(),
+                offset,
+                last_stable_offset,
+            },
+        )
+        .await
+        .and_then(|response| {
+            if let Response::AbortedTransactions(inner) = response {
+                inner.map_err(Into::into)
+            } else {
+                Err(Error::UnexpectedServiceResponse(Box::new(response)).into())
+            }
+        })
+        .map_err(Into::into)
+    }
+
+    #[instrument(skip_all)]
     async fn cluster_id(&self) -> Result<String> {
         self.serve(Context::default(), Request::ClusterId)
             .await
@@ -1477,6 +1510,15 @@ where
             Request::Maintain(now) => Ok(Response::Maintain(self.storage.maintain(now).await)),
             Request::MaintainTransactions(now) => Ok(Response::MaintainTransactions(
                 self.storage.maintain_transactions(now).await,
+            )),
+            Request::AbortedTransactions {
+                topition,
+                offset,
+                last_stable_offset,
+            } => Ok(Response::AbortedTransactions(
+                self.storage
+                    .aborted_transactions(&topition, offset, last_stable_offset)
+                    .await,
             )),
             Request::ClusterId => Ok(Response::ClusterId(self.storage.cluster_id().await)),
             Request::Node => Ok(Response::Node(self.storage.node().await)),

--- a/tansu-storage/src/slate/storage.rs
+++ b/tansu-storage/src/slate/storage.rs
@@ -39,6 +39,7 @@ use tansu_sans_io::{
     describe_topic_partitions_response::{
         DescribeTopicPartitionsResponsePartition, DescribeTopicPartitionsResponseTopic,
     },
+    fetch_response::AbortedTransaction,
     incremental_alter_configs_request::AlterConfigsResource,
     incremental_alter_configs_response::AlterConfigsResourceResponse,
     list_groups_response::ListedGroup,
@@ -2685,6 +2686,15 @@ impl Storage for Engine {
 
     async fn maintain_transactions(&self, _now: SystemTime) -> Result<()> {
         Ok(())
+    }
+
+    async fn aborted_transactions(
+        &self,
+        _topition: &Topition,
+        _offset: i64,
+        _last_stable_offset: i64,
+    ) -> Result<Vec<AbortedTransaction>> {
+        Ok(vec![])
     }
 
     async fn cluster_id(&self) -> Result<String> {


### PR DESCRIPTION
For a read_committed Fetch, the consumer has to know which transactions were aborted within the offset range it fetched, so it can discard those records. This adds a new Storage::aborted_transactions trait method that returns that list, stubbed for every backend:

- leaf engines (pg, null, dynostore, slate, limbo) return Ok(vec![])
- wrappers (lite, proxy, batch, latency, RequestChannel, Arc/Box, StorageContainer dispatch) forward to their inner storage
- the auth test mock gets an unimplemented!() stub
