### PR TITLE
feat(storage): abort timed-out transactions queries in postgres

### DIFF
--- a/etc/initdb.d/010-schema.sql
+++ b/etc/initdb.d/010-schema.sql
@@ -334,7 +334,10 @@ create table if not exists txn_detail (
     -- AddPartitionsToTxnRequest:
     -- If this is the first partition added to the transaction,
     -- the coordinator will also start the transaction timer
-    started_at timestamp,
+    --
+    -- timestamptz: the timeout sweep subtracts this from "now" to get elapsed
+    -- time; a zoneless timestamp would be off by the server's UTC offset.
+    started_at timestamptz,
     -- BEGIN, PREPARE_COMMIT, PREPARE_ABORT, COMMITTED or ABORTED
     --
     status text,

--- a/nisshi-storage/src/pg.rs
+++ b/nisshi-storage/src/pg.rs
@@ -1001,6 +1001,42 @@ impl Postgres {
     ) -> Result<ErrorCode> {
         debug!(cluster = ?self.cluster, ?transaction_id, ?producer_id, ?producer_epoch, ?committed);
 
+        // Lock the row before touching anything else: if a concurrent caller (a real
+        // EndTxn racing the maintain_transactions sweep, or a retried EndTxn) already
+        // finalized this transaction, this blocks until it commits, then sees the
+        // terminal status below and no-ops instead of writing a second marker.
+        let status = match self
+            .tx_prepare_query_opt(
+                tx,
+                "txn_detail_select_status_for_update.sql",
+                &[
+                    &self.cluster,
+                    &transaction_id,
+                    &producer_id,
+                    &producer_epoch,
+                ],
+            )
+            .await?
+        {
+            Some(row) => row
+                .try_get::<_, Option<String>>(0)? // nullable transaction status column -> Option<String>
+                .map(TxnState::try_from) // parse if present -> Option<Result<TxnState, _>>
+                .transpose()?, // Option<Result<_>> -> Result<Option<_>>, then `?` -> Option<TxnState>
+            None => None, // no txn_detail row found
+        };
+
+        // idempotent no-op: someone else already committed or aborted this transaction
+        if matches!(status, Some(TxnState::Committed) | Some(TxnState::Aborted)) {
+            debug!(
+                transaction_id,
+                producer_id,
+                producer_epoch,
+                ?status,
+                "already finalized"
+            );
+            return Ok(ErrorCode::None);
+        }
+
         let mut overlaps = vec![];
 
         let rows = self
@@ -3659,7 +3695,34 @@ impl Storage for Postgres {
         Ok(())
     }
 
-    async fn maintain_transactions(&self, _now: SystemTime) -> Result<()> {
+    #[instrument(skip(self), ret)]
+    async fn maintain_transactions(&self, now: SystemTime) -> Result<()> {
+        let c = self.connection().await?;
+
+        let rows = self
+            .prepare_query(
+                &c,
+                "txn_detail_select_timed_out.sql",
+                &[&self.cluster, &now],
+            )
+            .await?;
+
+        for row in rows {
+            let transaction_id = row.try_get::<_, String>(0)?;
+            let producer_id = row.try_get::<_, i64>(1)?;
+            let producer_epoch = row.try_get::<_, i16>(2)?;
+
+            if let Err(ref err) = self
+                .txn_end(&transaction_id, producer_id, producer_epoch, false)
+                .await
+            {
+                error!(
+                    ?err,
+                    transaction_id, producer_id, producer_epoch, "maintain_transactions"
+                );
+            }
+        }
+
         Ok(())
     }
 
@@ -3899,6 +3962,459 @@ mod tests {
              (last_stable={}, high_watermark={})",
             stage.last_stable,
             stage.high_watermark,
+        );
+
+        Ok(())
+    }
+
+    /// A transaction whose timeout has elapsed without the client calling `EndTxn` (a crashed
+    /// or abandoned producer) must be aborted by `maintain_transactions`, releasing the
+    /// `read_committed` last stable offset it was pinning.
+    #[tokio::test]
+    async fn maintain_transactions_aborts_timed_out_transaction() -> Result<()> {
+        let cluster = alphanumeric_string(15);
+
+        let storage = Postgres::builder(CONNECTION)?
+            .cluster(cluster.as_str())
+            .node(rng().random_range(0..i32::MAX))
+            .build();
+
+        if let Err(err) = storage.connection().await {
+            eprintln!("skipping maintain_transactions_aborts_timed_out_transaction: {err:?}");
+            return Ok(());
+        }
+
+        storage
+            .register_broker(BrokerRegistrationRequest {
+                broker_id: 111,
+                cluster_id: cluster.clone(),
+                incarnation_id: Uuid::now_v7(),
+                rack: None,
+            })
+            .await?;
+
+        let topic_name = alphanumeric_string(15);
+        let num_partitions = 1;
+
+        _ = storage
+            .create_topic(
+                CreatableTopic::default()
+                    .name(topic_name.clone())
+                    .num_partitions(num_partitions)
+                    .replication_factor(0)
+                    .assignments(Some([].into()))
+                    .configs(Some([].into())),
+                false,
+            )
+            .await?;
+
+        let topition = Topition::new(topic_name.clone(), 0);
+
+        // a transactional producer begins a transaction and produces, never commits
+        let transaction_id = alphanumeric_string(10);
+        let producer = storage
+            .init_producer(Some(transaction_id.as_str()), 10_000, Some(-1), Some(-1))
+            .await?;
+
+        _ = storage
+            .txn_add_partitions(TxnAddPartitionsRequest::VersionZeroToThree {
+                transaction_id: transaction_id.clone(),
+                producer_id: producer.id,
+                producer_epoch: producer.epoch,
+                topics: vec![
+                    AddPartitionsToTxnTopic::default()
+                        .name(topic_name.clone())
+                        .partitions(Some((0..num_partitions).collect())),
+                ],
+            })
+            .await?;
+
+        let batch = Batch::builder()
+            .record(Record::builder().value(Bytes::from_static(b"abandoned").into()))
+            .attributes(BatchAttribute::default().transaction(true).into())
+            .producer_id(producer.id)
+            .producer_epoch(producer.epoch)
+            .base_sequence(0)
+            .build()
+            .and_then(TryInto::try_into)?;
+
+        _ = storage
+            .produce(Some(transaction_id.as_str()), &topition, batch)
+            .await?;
+
+        let stage = storage.offset_stage(&topition).await?;
+
+        assert!(
+            stage.last_stable < stage.high_watermark,
+            "an open transaction must pin last_stable below the high watermark \
+             (last_stable={}, high_watermark={})",
+            stage.last_stable,
+            stage.high_watermark,
+        );
+
+        // no need to actually sleep past the timeout: `now` is a plain parameter,
+        // so pass a `now` far enough ahead that the 10s timeout has "elapsed".
+        storage
+            .maintain_transactions(SystemTime::now() + Duration::from_secs(3600))
+            .await?;
+
+        let stage = storage.offset_stage(&topition).await?;
+
+        assert_eq!(
+            stage.high_watermark, stage.last_stable,
+            "the timed-out transaction should have been aborted, releasing last_stable \
+             (last_stable={}, high_watermark={})",
+            stage.last_stable, stage.high_watermark,
+        );
+
+        Ok(())
+    }
+
+    /// A transaction that hasn't reached its own `transaction_timeout_ms` yet must be left
+    /// alone by the sweep -- it should not be aborted just because maintain_transactions ran.
+    #[tokio::test]
+    async fn maintain_transactions_leaves_transaction_before_timeout() -> Result<()> {
+        let cluster = alphanumeric_string(15);
+
+        let storage = Postgres::builder(CONNECTION)?
+            .cluster(cluster.as_str())
+            .node(rng().random_range(0..i32::MAX))
+            .build();
+
+        if let Err(err) = storage.connection().await {
+            eprintln!("skipping maintain_transactions_leaves_transaction_before_timeout: {err:?}");
+            return Ok(());
+        }
+
+        storage
+            .register_broker(BrokerRegistrationRequest {
+                broker_id: 111,
+                cluster_id: cluster.clone(),
+                incarnation_id: Uuid::now_v7(),
+                rack: None,
+            })
+            .await?;
+
+        let topic_name = alphanumeric_string(15);
+        let num_partitions = 1;
+
+        _ = storage
+            .create_topic(
+                CreatableTopic::default()
+                    .name(topic_name.clone())
+                    .num_partitions(num_partitions)
+                    .replication_factor(0)
+                    .assignments(Some([].into()))
+                    .configs(Some([].into())),
+                false,
+            )
+            .await?;
+
+        let topition = Topition::new(topic_name.clone(), 0);
+
+        let transaction_id = alphanumeric_string(10);
+        let producer = storage
+            .init_producer(Some(transaction_id.as_str()), 10_000, Some(-1), Some(-1))
+            .await?;
+
+        _ = storage
+            .txn_add_partitions(TxnAddPartitionsRequest::VersionZeroToThree {
+                transaction_id: transaction_id.clone(),
+                producer_id: producer.id,
+                producer_epoch: producer.epoch,
+                topics: vec![
+                    AddPartitionsToTxnTopic::default()
+                        .name(topic_name.clone())
+                        .partitions(Some((0..num_partitions).collect())),
+                ],
+            })
+            .await?;
+
+        let batch = Batch::builder()
+            .record(Record::builder().value(Bytes::from_static(b"still-active").into()))
+            .attributes(BatchAttribute::default().transaction(true).into())
+            .producer_id(producer.id)
+            .producer_epoch(producer.epoch)
+            .base_sequence(0)
+            .build()
+            .and_then(TryInto::try_into)?;
+
+        _ = storage
+            .produce(Some(transaction_id.as_str()), &topition, batch)
+            .await?;
+
+        let before = storage.offset_stage(&topition).await?;
+
+        // `now` is barely past `started_at`, nowhere near the 10s timeout.
+        storage
+            .maintain_transactions(SystemTime::now() + Duration::from_millis(50))
+            .await?;
+
+        let after = storage.offset_stage(&topition).await?;
+
+        assert_eq!(
+            before.last_stable, after.last_stable,
+            "a transaction within its timeout must not be touched by the sweep \
+             (before={}, after={})",
+            before.last_stable, after.last_stable,
+        );
+        assert!(
+            after.last_stable < after.high_watermark,
+            "the still-open transaction must remain pinned \
+             (last_stable={}, high_watermark={})",
+            after.last_stable,
+            after.high_watermark,
+        );
+
+        Ok(())
+    }
+
+    /// When a timed-out transaction overlaps an older, still-open transaction on the same
+    /// partition, the sweep must not finalize it out of order: it should stage to
+    /// PREPARE_ABORT and leave the last stable offset exactly where the older transaction
+    /// pins it, until that older transaction resolves too.
+    #[tokio::test]
+    async fn maintain_transactions_defers_when_older_overlapping_transaction_still_open()
+    -> Result<()> {
+        let cluster = alphanumeric_string(15);
+
+        let storage = Postgres::builder(CONNECTION)?
+            .cluster(cluster.as_str())
+            .node(rng().random_range(0..i32::MAX))
+            .build();
+
+        if let Err(err) = storage.connection().await {
+            eprintln!(
+                "skipping maintain_transactions_defers_when_older_overlapping_transaction_still_open: {err:?}"
+            );
+            return Ok(());
+        }
+
+        storage
+            .register_broker(BrokerRegistrationRequest {
+                broker_id: 111,
+                cluster_id: cluster.clone(),
+                incarnation_id: Uuid::now_v7(),
+                rack: None,
+            })
+            .await?;
+
+        let topic_name = alphanumeric_string(15);
+        let num_partitions = 1;
+
+        _ = storage
+            .create_topic(
+                CreatableTopic::default()
+                    .name(topic_name.clone())
+                    .num_partitions(num_partitions)
+                    .replication_factor(0)
+                    .assignments(Some([].into()))
+                    .configs(Some([].into())),
+                false,
+            )
+            .await?;
+
+        let topition = Topition::new(topic_name.clone(), 0);
+
+        // producer A: opens first, given a long timeout, and never resolves -- it's the
+        // oldest open transaction on this partition, so it pins the last stable offset.
+        let txn_a = alphanumeric_string(10);
+        let producer_a = storage
+            .init_producer(Some(txn_a.as_str()), 10_000_000, Some(-1), Some(-1))
+            .await?;
+
+        _ = storage
+            .txn_add_partitions(TxnAddPartitionsRequest::VersionZeroToThree {
+                transaction_id: txn_a.clone(),
+                producer_id: producer_a.id,
+                producer_epoch: producer_a.epoch,
+                topics: vec![
+                    AddPartitionsToTxnTopic::default()
+                        .name(topic_name.clone())
+                        .partitions(Some((0..num_partitions).collect())),
+                ],
+            })
+            .await?;
+
+        let batch_a = Batch::builder()
+            .record(Record::builder().value(Bytes::from_static(b"a").into()))
+            .attributes(BatchAttribute::default().transaction(true).into())
+            .producer_id(producer_a.id)
+            .producer_epoch(producer_a.epoch)
+            .base_sequence(0)
+            .build()
+            .and_then(TryInto::try_into)?;
+
+        _ = storage
+            .produce(Some(txn_a.as_str()), &topition, batch_a)
+            .await?;
+
+        // producer B: opens second, on the same partition, with a short timeout -- it will
+        // be picked up by the sweep, but must defer to A.
+        let txn_b = alphanumeric_string(10);
+        let producer_b = storage
+            .init_producer(Some(txn_b.as_str()), 10_000, Some(-1), Some(-1))
+            .await?;
+
+        _ = storage
+            .txn_add_partitions(TxnAddPartitionsRequest::VersionZeroToThree {
+                transaction_id: txn_b.clone(),
+                producer_id: producer_b.id,
+                producer_epoch: producer_b.epoch,
+                topics: vec![
+                    AddPartitionsToTxnTopic::default()
+                        .name(topic_name.clone())
+                        .partitions(Some((0..num_partitions).collect())),
+                ],
+            })
+            .await?;
+
+        let batch_b = Batch::builder()
+            .record(Record::builder().value(Bytes::from_static(b"b").into()))
+            .attributes(BatchAttribute::default().transaction(true).into())
+            .producer_id(producer_b.id)
+            .producer_epoch(producer_b.epoch)
+            .base_sequence(0)
+            .build()
+            .and_then(TryInto::try_into)?;
+
+        _ = storage
+            .produce(Some(txn_b.as_str()), &topition, batch_b)
+            .await?;
+
+        let before = storage.offset_stage(&topition).await?;
+
+        // far enough ahead for B's 10s timeout to have elapsed, nowhere near A's ~10,000s one.
+        storage
+            .maintain_transactions(SystemTime::now() + Duration::from_secs(20))
+            .await?;
+
+        let after = storage.offset_stage(&topition).await?;
+
+        assert_eq!(
+            before.last_stable, after.last_stable,
+            "B must not advance last_stable while A (older, still open) remains pinned \
+             (before={}, after={})",
+            before.last_stable, after.last_stable,
+        );
+        assert!(
+            after.last_stable < after.high_watermark,
+            "A is still open, so last_stable must remain pinned below the high watermark \
+             (last_stable={}, high_watermark={})",
+            after.last_stable,
+            after.high_watermark,
+        );
+
+        Ok(())
+    }
+
+    /// The status guard added to end_in_tx must make a second, stale call safely idempotent --
+    /// this is the exact race maintain_transactions and a genuinely concurrent client EndTxn
+    /// could hit: a candidate found by the sweep's query that a real client finalizes first.
+    #[tokio::test]
+    async fn txn_end_after_already_finalized_is_a_no_op() -> Result<()> {
+        let cluster = alphanumeric_string(15);
+
+        let storage = Postgres::builder(CONNECTION)?
+            .cluster(cluster.as_str())
+            .node(rng().random_range(0..i32::MAX))
+            .build();
+
+        if let Err(err) = storage.connection().await {
+            eprintln!("skipping txn_end_after_already_finalized_is_a_no_op: {err:?}");
+            return Ok(());
+        }
+
+        storage
+            .register_broker(BrokerRegistrationRequest {
+                broker_id: 111,
+                cluster_id: cluster.clone(),
+                incarnation_id: Uuid::now_v7(),
+                rack: None,
+            })
+            .await?;
+
+        let topic_name = alphanumeric_string(15);
+        let num_partitions = 1;
+
+        _ = storage
+            .create_topic(
+                CreatableTopic::default()
+                    .name(topic_name.clone())
+                    .num_partitions(num_partitions)
+                    .replication_factor(0)
+                    .assignments(Some([].into()))
+                    .configs(Some([].into())),
+                false,
+            )
+            .await?;
+
+        let topition = Topition::new(topic_name.clone(), 0);
+
+        let transaction_id = alphanumeric_string(10);
+        let producer = storage
+            .init_producer(Some(transaction_id.as_str()), 10_000, Some(-1), Some(-1))
+            .await?;
+
+        _ = storage
+            .txn_add_partitions(TxnAddPartitionsRequest::VersionZeroToThree {
+                transaction_id: transaction_id.clone(),
+                producer_id: producer.id,
+                producer_epoch: producer.epoch,
+                topics: vec![
+                    AddPartitionsToTxnTopic::default()
+                        .name(topic_name.clone())
+                        .partitions(Some((0..num_partitions).collect())),
+                ],
+            })
+            .await?;
+
+        let batch = Batch::builder()
+            .record(Record::builder().value(Bytes::from_static(b"raced").into()))
+            .attributes(BatchAttribute::default().transaction(true).into())
+            .producer_id(producer.id)
+            .producer_epoch(producer.epoch)
+            .base_sequence(0)
+            .build()
+            .and_then(TryInto::try_into)?;
+
+        _ = storage
+            .produce(Some(transaction_id.as_str()), &topition, batch)
+            .await?;
+
+        // the "real client" wins the race and commits first.
+        _ = storage
+            .txn_end(&transaction_id, producer.id, producer.epoch, true)
+            .await?;
+
+        let after_commit = storage.offset_stage(&topition).await?;
+
+        assert_eq!(
+            after_commit.last_stable, after_commit.high_watermark,
+            "the committed transaction should have released last_stable \
+             (last_stable={}, high_watermark={})",
+            after_commit.last_stable, after_commit.high_watermark,
+        );
+
+        // the sweep's stale view still thinks it should abort the same transaction.
+        let error_code = storage
+            .txn_end(&transaction_id, producer.id, producer.epoch, false)
+            .await?;
+
+        assert_eq!(
+            ErrorCode::None,
+            error_code,
+            "a duplicate txn_end on an already-finalized transaction must be a no-op, \
+             not an error"
+        );
+
+        let after_duplicate = storage.offset_stage(&topition).await?;
+
+        assert_eq!(
+            after_commit.high_watermark, after_duplicate.high_watermark,
+            "the duplicate call must not append a second control-batch marker \
+             (high_watermark before={}, after={})",
+            after_commit.high_watermark, after_duplicate.high_watermark,
         );
 
         Ok(())

--- a/nisshi-storage/src/sql.rs
+++ b/nisshi-storage/src/sql.rs
@@ -305,6 +305,14 @@ pub(crate) static SQL: LazyLock<Cache> = LazyLock::new(|| {
             include_sql!("sql/txn_detail_select_for_update.sql"),
         ),
         (
+            "txn_detail_select_status_for_update.sql",
+            include_sql!("sql/txn_detail_select_status_for_update.sql"),
+        ),
+        (
+            "txn_detail_select_timed_out.sql",
+            include_sql!("sql/txn_detail_select_timed_out.sql"),
+        ),
+        (
             "txn_detail_select.sql",
             include_sql!("sql/txn_detail_select.sql"),
         ),

--- a/nisshi-storage/src/sql/txn_detail_select_status_for_update.sql
+++ b/nisshi-storage/src/sql/txn_detail_select_status_for_update.sql
@@ -1,5 +1,5 @@
 -- -*- mode: sql; sql-product: postgres; -*-
--- Copyright ⓒ 2024-2025 Peter Morgan <peter.james.morgan@gmail.com>
+-- Copyright ⓒ 2024-2026 Peter Morgan <peter.james.morgan@gmail.com>
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -13,12 +13,11 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-update txn_detail
+-- prepare txn_detail_select_status_for_update (text, text, bigint, smallint) as
+-- Locks the txn_detail row and returns its status, so an EndTxn racing the
+-- abort sweep (or a retried EndTxn) cannot double-finalize the transaction.
 
-set
-
-started_at = current_timestamp,
-status = 'BEGIN'
+select txn_d.status
 
 from
 
@@ -26,6 +25,7 @@ cluster c
 join producer p on p.cluster = c.id
 join producer_epoch pe on pe.producer = p.id
 join txn on txn.cluster = c.id and txn.producer = p.id
+join txn_detail txn_d on txn_d."transaction" = txn.id and txn_d.producer_epoch = pe.id
 
 where
 
@@ -33,12 +33,5 @@ c.name = $1
 and txn.name = $2
 and p.id = $3
 and pe.epoch = $4
-and txn_detail."transaction" = txn.id
-and txn_detail.producer_epoch = pe.id
--- Reset only a fresh row or one whose previous transaction has resolved --
--- never one still in flight (BEGIN/PREPARE_*). No started_at check needed:
--- it is only ever set together with status, so status alone decides.
-and (
-    txn_detail.status is null
-    or txn_detail.status in ('COMMITTED', 'ABORTED')
-);
+
+for update of txn_d;

--- a/nisshi-storage/src/sql/txn_detail_select_timed_out.sql
+++ b/nisshi-storage/src/sql/txn_detail_select_timed_out.sql
@@ -1,5 +1,5 @@
 -- -*- mode: sql; sql-product: postgres; -*-
--- Copyright ⓒ 2024-2025 Peter Morgan <peter.james.morgan@gmail.com>
+-- Copyright ⓒ 2024-2026 Peter Morgan <peter.james.morgan@gmail.com>
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -13,12 +13,10 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-update txn_detail
+-- prepare txn_detail_select_timed_out (text, timestamp) as
+-- Returns transactions still in BEGIN past their timeout, for the abort sweep.
 
-set
-
-started_at = current_timestamp,
-status = 'BEGIN'
+select txn.name, p.id, pe.epoch
 
 from
 
@@ -26,19 +24,14 @@ cluster c
 join producer p on p.cluster = c.id
 join producer_epoch pe on pe.producer = p.id
 join txn on txn.cluster = c.id and txn.producer = p.id
+join txn_detail txn_d on txn_d."transaction" = txn.id and txn_d.producer_epoch = pe.id
 
 where
 
 c.name = $1
-and txn.name = $2
-and p.id = $3
-and pe.epoch = $4
-and txn_detail."transaction" = txn.id
-and txn_detail.producer_epoch = pe.id
--- Reset only a fresh row or one whose previous transaction has resolved --
--- never one still in flight (BEGIN/PREPARE_*). No started_at check needed:
--- it is only ever set together with status, so status alone decides.
-and (
-    txn_detail.status is null
-    or txn_detail.status in ('COMMITTED', 'ABORTED')
-);
+and txn_d.status = 'BEGIN'
+and txn_d.started_at is not null
+-- $2 is the sweep's "now": the transaction has timed out when more than its
+-- own transaction_timeout_ms of elapsed time separates it from started_at.
+and (extract(epoch from cast($2 as timestamp)) - extract(epoch from txn_d.started_at)) * 1000
+    > txn_d.transaction_timeout_ms;


### PR DESCRIPTION

- abort transactions whose transaction_timeout_ms has elapsed via the existing end_in_tx path, releasing the last stable offset they pin
- guard end_in_tx with a status SELECT ... FOR UPDATE against a racing or retried EndTxn
- let txn_detail's timer reset on a resolved (COMMITTED/ABORTED) row, not just an untouched one
- txn_detail.started_at becomes timestamptz